### PR TITLE
Publishing migration fails due to wrong path

### DIFF
--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -21,7 +21,7 @@ class ActivitylogServiceProvider extends ServiceProvider
             $timestamp = date('Y_m_d_His', time());
 
             $this->publishes([
-                __DIR__.'/../migrations/create_activity_log_table.stub' => database_path("/migrations/{$timestamp}_create_activity_log_table.php"),
+                __DIR__.'/../migrations/create_activity_log_table.php.stub' => database_path("/migrations/{$timestamp}_create_activity_log_table.php"),
             ], 'migrations');
         }
     }


### PR DESCRIPTION
Missing .php. in migrations/create_activity_log_table.stub