### PR TITLE
Add support for Laravel 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,16 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/config": "^5.1",
-        "illuminate/database": "^5.1",
-        "illuminate/support": "^5.1",
+        "illuminate/config": "^5.1.24",
+        "illuminate/database": "^5.1.24",
+        "illuminate/support": "^5.1.24",
         "spatie/string": "^2.1"
 
     },
     "require-dev": {
         "phpunit/phpunit": "5.*",
-        "orchestra/testbench": "^3.1"
+        "orchestra/testbench": "^3.1",
+        "fzaninotto/faker": "~1.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,15 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/config": "^5.2",
-        "illuminate/database": "^5.2",
-        "illuminate/support": "^5.2.21",
+        "illuminate/config": "^5.1",
+        "illuminate/database": "^5.1",
+        "illuminate/support": "^5.1",
         "spatie/string": "^2.1"
 
     },
     "require-dev": {
         "phpunit/phpunit": "5.*",
-        "orchestra/testbench": "^3.2"
+        "orchestra/testbench": "^3.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -160,9 +160,7 @@ class ActivityLogger
 
             $attributeValue = $activity->$attribute;
 
-            if ($attributeValue instanceof Model) {
-                $attributeValue = $attributeValue->toArray();
-            }
+            $attributeValue = $attributeValue->toArray();
 
             return array_get($attributeValue, $propertyName, $match);
         }, $description);

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -36,14 +36,14 @@ class Activity extends Eloquent
      */
     public function getExtraProperty(string $propertyName)
     {
-        return array_get($this->properties, $propertyName);
+        return array_get($this->properties->toArray(), $propertyName);
     }
 
     public function getChangesAttribute(): Collection
     {
-        return $this->properties->filter(function ($value, $key) {
+        return collect(array_filter($this->properties->toArray(), function ($key) {
             return in_array($key, ['attributes', 'old']);
-        });
+        }, ARRAY_FILTER_USE_KEY));
     }
 
     public function scopeInLog(Builder $query, ...$logNames): Builder

--- a/tests/ActivityloggerTest.php
+++ b/tests/ActivityloggerTest.php
@@ -4,7 +4,6 @@ namespace Spatie\Activitylog\Test;
 
 use Auth;
 use Illuminate\Support\Collection;
-use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\Article;
 use Spatie\Activitylog\Test\Models\User;
@@ -129,13 +128,12 @@ class ActivityloggerTest extends TestCase
 
     /**
      * @test
+     * @expectedException \Spatie\Activitylog\Exceptions\CouldNotLogActivity
      *
      * @requires !Travis
      */
     public function it_will_throw_an_exception_if_it_cannot_translate_a_causer_id()
     {
-        $this->expectException(CouldNotLogActivity::class);
-
         activity()->causedBy(999);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -47,6 +47,9 @@ abstract class TestCase extends OrchestraTestCase
         ]);
 
         $app['config']->set('auth.providers.users.model', User::class);
+        
+        // to support testing in Laravel 5.1
+        $app['config']->set('auth.model', User::class);
 
         $app['config']->set('app.key', '6rE9Nz59bGRbeMATftriyQjrpF7DcOQm');
     }


### PR DESCRIPTION
In answer to this issue: https://github.com/spatie/laravel-activitylog/issues/7, I added support for Laravel 5.1.

Do you also want to support PHP 5.6? Since Laravel 5.1 runs on PHP 5.6...