### PR TITLE
Clarify `$activity->changes` doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Calling `$activity->changes` will return this array:
 ```php
 [
    'attributes' => [
-        'name' => 'original name',
+        'name' => 'updated name',
         'text' => 'Lorum',
     ],
     'old' => [
-        'name' => 'updated name',
+        'name' => 'original name',
         'text' => 'Lorum',
     ],
 ];


### PR DESCRIPTION
I looked into the source and it looks like `attributes` will always reflect the current status (even immediately following an update) and `old` will show the previous values (if changes are detected). I think this will clear up some confusion- at least it will clear my own confusion ;)