### PR TITLE
specify custom logName for each model

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -20,11 +20,14 @@ trait LogsActivity
 
                 $description = $model->getDescriptionForEvent($eventName);
 
+                $logName = $model->getLogToUse();
+
                 if ($description == '') {
                     return;
                 }
 
                 app(ActivityLogger::class)
+                    ->useLog($logName)
                     ->performedOn($model)
                     ->withProperties($model->attributeValuesToBeLogged($eventName))
                     ->log($description);
@@ -41,6 +44,11 @@ trait LogsActivity
     public function getDescriptionForEvent(string $eventName): string
     {
         return $eventName;
+    }
+
+    public function getLogToUse(): string
+    {
+        return config('laravel-activitylog.default_log_name');
     }
 
     /*

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -10,6 +10,7 @@ class LogsActivityTest extends TestCase
 {
     /** @var \Spatie\Activitylog\Test\Article|\Spatie\Activitylog\Traits\LogsActivity  */
     protected $article;
+    protected $articleWithCustomLog;
 
     public function setUp()
     {
@@ -17,6 +18,15 @@ class LogsActivityTest extends TestCase
 
         $this->article = new class extends Article {
             use LogsActivity;
+        };
+
+        $this->articleWithCustomLog = new class extends Article {
+            use LogsActivity;
+
+            public function getLogToUse()
+            {
+                return 'custom_log';
+            }
         };
 
         $this->assertCount(0, Activity::all());
@@ -75,6 +85,19 @@ class LogsActivityTest extends TestCase
         $this->assertCount(2, $activities);
     }
 
+    /** @test */
+    public function it_can_log_activity_to_log_named_in_the_model()
+    {
+        $article = $this->createArticle();
+        $articleWithCustomLog = $this->createArticleWithCustomLog();
+        $this->assertEquals('default', $article->getLogToUse());
+        $this->assertEquals('custom_log', $articleWithCustomLog->getLogToUse());
+        $this->assertEquals($article->id, Activity::inLog('default')->first()->subject->id);
+        $this->assertEquals($articleWithCustomLog->id, Activity::inLog('custom_log')->first()->subject->id);
+        $this->assertCount(1, Activity::inLog('default')->get());
+        $this->assertCount(1, Activity::inLog('custom_log')->get());
+    }
+
 
     protected function createArticle(): Article
     {
@@ -85,6 +108,13 @@ class LogsActivityTest extends TestCase
         return $article;
     }
 
+    protected function createArticleWithCustomLog(): Article
+    {
+        $article = new $this->articleWithCustomLog();
+        $article->name = 'my name';
+        $article->save();
 
-
+        return $article;
+    }
+    
 }


### PR DESCRIPTION
This will allow each model using the `LogsActivity` trait to specify the `logName` to use. Works just like `getDescriptionForEvent` function. Falls back to `default` log if `getLogToUse()` is not overridden.

Trying to address #15 