### PR TITLE
Use Config Repo Contract.

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Activitylog;
 
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;


### PR DESCRIPTION
This fixes error with orchestra platform and possibly any other custom implementation:

```sh
Type error: Argument 2 passed to Spatie\Activitylog\ActivityLogger::__construct() must be an instance of Illuminate\Config\Repository, instance of Orchestra\Config\Repository given
```