### PR TITLE
Support softdeleted models

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ return [
      * we'll using this log name.
      */
     'default_log_name' => 'default'
+
+    /**
+     * When set to true, the subject returns soft deleted models
+     */
+     'subject_withTrashed' => false
 ];
 ```
 

--- a/config/laravel-activitylog.php
+++ b/config/laravel-activitylog.php
@@ -13,5 +13,10 @@ return [
      * When not specifying a log name when logging activity
      * we'll using this log name.
      */
-    'default_log_name' => 'default'
+    'default_log_name' => 'default',
+    
+    /**
+     * When set to true, the subject returns soft deleted models
+     */
+     'subject_withTrashed' => false
 ];

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -19,6 +19,9 @@ class Activity extends Eloquent
 
     public function subject(): MorphTo
     {
+        if (config('laravel-activitylog.subject_withTrashed'))
+            return $this->morphTo()->withTrashed();
+            
         return $this->morphTo();
     }
 

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -76,6 +76,25 @@ class LogsActivityTest extends TestCase
     }
 
     /** @test */
+    public function it_can_fetch_all_activity_for_a_deleted_model()
+    {
+        $article = $this->createArticle();
+
+        $article->name = 'changed name';
+        $article->save();
+
+        $article->delete();
+
+        $activities = $article->activity;
+
+        $this->assertCount(3, $activities);
+
+        $this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
+        $this->assertEquals('deleted', $this->getLastActivity()->description);
+    }
+
+    /** @test */
     public function it_can_log_activity_to_log_named_in_the_model()
     {
         $articleClass = new class extends Article {

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -78,6 +78,8 @@ class LogsActivityTest extends TestCase
     /** @test */
     public function it_can_fetch_all_activity_for_a_deleted_model()
     {
+        $this->app['config']->set('laravel-activitylog.subject_withTrashed', true);
+        
         $article = $this->createArticle();
 
         $article->name = 'changed name';
@@ -92,6 +94,7 @@ class LogsActivityTest extends TestCase
         $this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
         $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
         $this->assertEquals('deleted', $this->getLastActivity()->description);
+        $this->assertEquals('changed name', $this->getLastActivity()->subject->name);
     }
 
     /** @test */

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -3,9 +3,12 @@
 namespace Spatie\Activitylog\Test\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Article extends Model
 {
+    use SoftDeletes;
+
     protected $table = 'articles';
 
     protected $guarded = [];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -86,6 +86,7 @@ abstract class TestCase extends OrchestraTestCase
                 $table->string('name')->nullable();
                 $table->string('text')->nullable();
                 $table->timestamps();
+                $table->softDeletes();
             });
         });
     }


### PR DESCRIPTION
When using softdeletes with our models, we still want to request some properties of the model, even if the model is deleted. This way, we remain a full history of the model in the activity log.
The option to enable is set via a new variable in the config file.
Feel free to change the naming if needed.