### PR TITLE
Supports for PHP5.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 composer.lock
 docs
 vendor
+
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
             "email": "sebastian@spatie.be",
             "homepage": "https://spatie.be",
             "role": "Developer"
-        },
+        }
     ],
     "require": {
         "php" : ">=5.6",
@@ -49,7 +49,6 @@
             "Spatie\\Activitylog\\Test\\": "tests"
         }
     },
-
     "scripts": {
         "test": "vendor/bin/phpunit"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
             "email": "sebastian@spatie.be",
             "homepage": "https://spatie.be",
             "role": "Developer"
-        }
+        },
     ],
     "require": {
-        "php" : "^7.0",
+        "php" : ">=5.6",
         "illuminate/config": "^5.1.24",
         "illuminate/database": "^5.1.24",
         "illuminate/support": "^5.1.24",

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -84,26 +84,42 @@ class ActivityLogger
      *
      * @return $this
      */
-    public function withProperty(string $key, $value)
+    public function withProperty($key, $value)
     {
         $this->properties->put($key, $value);
 
         return $this;
     }
 
-    public function useLog(string $logName)
+
+    /**
+     * @param string $logName
+     *
+     * @return $this
+     */
+    public function useLog($logName)
     {
         $this->logName = $logName;
 
         return $this;
     }
 
-    public function inLog(string $logName)
+
+    /**
+     * @param string $logName
+     *
+     * @return \Spatie\Activitylog\ActivityLogger
+     */
+    public function inLog($logName)
     {
         return $this->useLog($logName);
     }
 
-    public function log(string $description)
+
+    /**
+     * @param string $description
+     */
+    public function log($description)
     {
         $activity = new Activity();
 
@@ -131,7 +147,7 @@ class ActivityLogger
      *
      * @throws \Spatie\Activitylog\Exceptions\CouldNotLogActivity
      */
-    protected function normalizeCauser($modelOrId): Model
+    protected function normalizeCauser($modelOrId)
     {
         if ($modelOrId instanceof Model) {
             return $modelOrId;
@@ -144,7 +160,14 @@ class ActivityLogger
         throw CouldNotLogActivity::couldNotDetermineUser($modelOrId);
     }
 
-    protected function replacePlaceholders(string $description, Activity $activity): string
+
+    /**
+     * @param string                              $description
+     * @param \Spatie\Activitylog\Models\Activity $activity
+     *
+     * @return string
+     */
+    protected function replacePlaceholders($description, Activity $activity)
     {
         return preg_replace_callback('/:[a-z0-9._-]+/i', function ($match) use ($activity) {
 

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -17,12 +17,20 @@ class Activity extends Eloquent
         'properties' => 'collection',
     ];
 
-    public function subject(): MorphTo
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function subject()
     {
         return $this->morphTo();
     }
 
-    public function causer(): MorphTo
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function causer()
     {
         return $this->morphTo();
     }
@@ -34,19 +42,30 @@ class Activity extends Eloquent
      *
      * @return mixed
      */
-    public function getExtraProperty(string $propertyName)
+    public function getExtraProperty($propertyName)
     {
         return array_get($this->properties->toArray(), $propertyName);
     }
 
-    public function getChangesAttribute(): Collection
+
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    public function getChangesAttribute()
     {
         return collect(array_filter($this->properties->toArray(), function ($key) {
             return in_array($key, ['attributes', 'old']);
         }, ARRAY_FILTER_USE_KEY));
     }
 
-    public function scopeInLog(Builder $query, ...$logNames): Builder
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param array                                 ...$logNames
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeInLog(Builder $query, ...$logNames)
     {
         if (is_array($logNames[0])) {
             $logNames = $logNames[0];

--- a/src/Traits/CausesActivity.php
+++ b/src/Traits/CausesActivity.php
@@ -7,13 +7,21 @@ use Spatie\Activitylog\Models\Activity;
 
 trait CausesActivity
 {
-    public function activity(): MorphMany
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function activity()
     {
         return $this->morphMany(Activity::class, 'causer');
     }
 
-    /** @deprecated Use activity() instead */
-    public function loggedActivity(): MorphMany
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     * @deprecated Use activity() instead
+     */
+    public function loggedActivity()
     {
         return $this->activity();
     }

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -22,7 +22,11 @@ trait DetectsChanges
         }
     }
 
-    public function attributesToBeLogged(): array
+
+    /**
+     * @return array
+     */
+    public function attributesToBeLogged()
     {
         if (!isset(static::$logAttributes)) {
             return [];
@@ -31,7 +35,13 @@ trait DetectsChanges
         return static::$logAttributes;
     }
 
-    public function attributeValuesToBeLogged(string $processingEvent): array
+
+    /**
+     * @param string $processingEvent
+     *
+     * @return array
+     */
+    public function attributeValuesToBeLogged($processingEvent)
     {
         if (!count($this->attributesToBeLogged())) {
             return [];
@@ -48,7 +58,13 @@ trait DetectsChanges
         return $properties;
     }
 
-    public static function logChanges(Model $model): array
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return array
+     */
+    public static function logChanges(Model $model)
     {
         return collect($model)->only($model->attributesToBeLogged())->toArray();
     }

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -36,17 +36,33 @@ trait LogsActivity
         });
     }
 
-    public function activity(): MorphMany
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function activity()
     {
         return $this->morphMany(Activity::class, 'subject');
     }
 
-    public function getDescriptionForEvent(string $eventName): string
+
+    /**
+     * @param string $eventName
+     *
+     * @return string
+     */
+    public function getDescriptionForEvent($eventName)
     {
         return $eventName;
     }
 
-    public function getLogNameToUse(string $eventName = ''): string
+
+    /**
+     * @param string $eventName
+     *
+     * @return string
+     */
+    public function getLogNameToUse($eventName = '')
     {
         return config('laravel-activitylog.default_log_name');
     }
@@ -54,7 +70,10 @@ trait LogsActivity
     /*
      * Get the event names that should be recorded.
      */
-    protected static function eventsToBeRecorded(): Collection
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    protected static function eventsToBeRecorded()
     {
         if (isset(static::$recordEvents)) {
             return collect(static::$recordEvents);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,10 +3,15 @@
 use Spatie\Activitylog\ActivityLogger;
 
 if (!function_exists('activity')) {
-    function activity(string $logName = null): ActivityLogger
+    /**
+     * @param string|null $logName
+     *
+     * @return \Spatie\Activitylog\ActivityLogger
+     */
+    function activity($logName = null)
     {
         $defaultLogName = config('laravel-activitylog.default_log_name');
 
-        return app(ActivityLogger::class)->useLog($logName ?? $defaultLogName);
+        return app(ActivityLogger::class)->useLog(isset($logName) ? $logName : $defaultLogName);
     }
 }

--- a/tests/ActivityModelTest.php
+++ b/tests/ActivityModelTest.php
@@ -10,7 +10,7 @@ class ActivityModelTest extends TestCase
     {
         parent::setUp();
 
-        collect(range(1, 5))->each(function (int $index) {
+        collect(range(1, 5))->each(function ($index) {
             $logName = "log{$index}";
             activity($logName)->log('hello everybody');
         });

--- a/tests/CleanActivitylogCommandTest.php
+++ b/tests/CleanActivitylogCommandTest.php
@@ -20,7 +20,7 @@ class CleanActivitylogCommandTest extends TestCase
     /** @test */
     public function it_can_clean_the_activity_log()
     {
-        collect(range(1, 60))->each(function (int $index) {
+        collect(range(1, 60))->each(function ($index) {
             Activity::create([
                 'description' => "item {$index}",
                 'created_at' => Carbon::now()->subDays($index)->startOfDay(),

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -6,6 +6,19 @@ use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\Article;
 use Spatie\Activitylog\Traits\LogsActivity;
 
+class DetectsChangesTestSetupMockArticle extends Article
+{
+    static $logAttributes = ['name', 'text'];
+
+    use LogsActivity;
+}
+class DetectsChangesTestMockArticle extends Article
+{
+    static $logAttributes = [];
+
+    use LogsActivity;
+}
+
 class DetectsChangesTest extends TestCase
 {
     /** @var \Spatie\Activitylog\Test\Article|\Spatie\Activitylog\Traits\LogsActivity */
@@ -15,12 +28,7 @@ class DetectsChangesTest extends TestCase
     {
         parent::setUp();
 
-        $this->article = new class extends Article
-        {
-            static $logAttributes = ['name', 'text'];
-            
-            use LogsActivity;
-        };
+        $this->article = new DetectsChangesTestSetupMockArticle();
 
         $this->assertCount(0, Activity::all());
     }
@@ -66,12 +74,7 @@ class DetectsChangesTest extends TestCase
     /** @test */
     public function it_will_store_no_changes_when_not_logging_attributes()
     {
-        $articleClass = new class extends Article
-        {
-            static $logAttributes = [];
-
-            use LogsActivity;
-        };
+        $articleClass = new DetectsChangesTestMockArticle();
 
         $article = new $articleClass;
 
@@ -98,7 +101,11 @@ class DetectsChangesTest extends TestCase
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes);
     }
 
-    protected function createArticle(): Article
+
+    /**
+     * @return \Spatie\Activitylog\Test\Models\Article
+     */
+    protected function createArticle()
     {
         $article = new $this->article();
         $article->name = 'my name';

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -6,6 +6,15 @@ use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\Article;
 use Spatie\Activitylog\Traits\LogsActivity;
 
+class LogActivityTestMockArticle extends Article {
+    use LogsActivity;
+
+    public function getLogNameToUse()
+    {
+        return 'custom_log';
+    }
+};
+
 class LogsActivityTest extends TestCase
 {
     /** @var \Spatie\Activitylog\Test\Article|\Spatie\Activitylog\Traits\LogsActivity  */
@@ -15,9 +24,7 @@ class LogsActivityTest extends TestCase
     {
         parent::setUp();
 
-        $this->article = new class extends Article {
-            use LogsActivity;
-        };
+        $this->article = new LogActivityTestMockArticle(); 
 
         $this->assertCount(0, Activity::all());
     }
@@ -78,14 +85,7 @@ class LogsActivityTest extends TestCase
     /** @test */
     public function it_can_log_activity_to_log_named_in_the_model()
     {
-        $articleClass = new class extends Article {
-            use LogsActivity;
-
-            public function getLogNameToUse()
-            {
-                return 'custom_log';
-            }
-        };
+        $articleClass = new LogActivityTestMockArticle();
 
         $article = new $articleClass();
         $article->name = 'my name';
@@ -95,7 +95,11 @@ class LogsActivityTest extends TestCase
         $this->assertCount(1, Activity::inLog('custom_log')->get());
     }
 
-    protected function createArticle(): Article
+
+    /**
+     * @return \Spatie\Activitylog\Test\Models\Article
+     */
+    protected function createArticle()
     {
         $article = new $this->article();
         $article->name = 'my name';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -73,14 +73,18 @@ abstract class TestCase extends OrchestraTestCase
         (new \CreateActivityLogTable())->up();
     }
 
-    public function getTempDirectory(): string
+
+    /**
+     * @return string
+     */
+    public function getTempDirectory()
     {
         return __DIR__.'/temp';
     }
 
     protected function createTables(...$tableNames)
     {
-        collect($tableNames)->each(function (string $tableName) {
+        collect($tableNames)->each(function ($tableName) {
             $this->app['db']->connection()->getSchemaBuilder()->create($tableName, function (Blueprint $table) {
                 $table->increments('id');
                 $table->string('name')->nullable();
@@ -92,7 +96,7 @@ abstract class TestCase extends OrchestraTestCase
 
     protected function seedModels(...$modelClasses)
     {
-        collect($modelClasses)->each(function (string $modelClass) {
+        collect($modelClasses)->each(function ($modelClass) {
             foreach (range(1, 0) as $index) {
                 $modelClass::create(['name' => "name {$index}"]);
             }


### PR DESCRIPTION
PHP 7 is relatively new to the world. 
In development environment we can build with php7 easily, but maybe not on some existing infrastructure.

This PR is simply reverting php7 syntax into php5.6 in all the `.php` files, including `tests/*`.
I suggest you *checkout a branch* `php56` and merge it, tag with 1.2.1-php56, probably.

Thank you for reading.