### PR TITLE
Allow specifying attributes which will not cause an activity log to be generated.

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -18,6 +18,10 @@ trait LogsActivity
 
             return static::$eventName(function (Model $model) use ($eventName) {
 
+                if (count(array_except($model->getDirty(), $model->attributesToBeIgnored())) === 0) {
+                    return;
+                }
+
                 $description = $model->getDescriptionForEvent($eventName);
 
                 $logName = $model->getLogNameToUse($eventName);
@@ -65,5 +69,14 @@ trait LogsActivity
             'updated',
             'deleted',
         ]);
+    }
+
+    public function attributesToBeIgnored(): array
+    {
+        if (!isset(static::$ignoreChangedAttributes)) {
+            return [];
+        }
+
+        return static::$ignoreChangedAttributes;
     }
 }


### PR DESCRIPTION
When only attributes specified in the model's static `$ignoreChangedAttributes` array have changed, a new activity log will not be written.

This is useful to ignore insignificant changes, such as updating a `last_login_at` field in a User model that updates with each login.