### PR TITLE
Update README.md - fix example on event logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $lastLoggedActivity->description; //returns 'Look, I logged something'
 ```
 
 
-Here's an example on [event logging](/laravel-activitylog/v1/advanced-usage/logging-model-events).
+Here's an example on [event logging](https://docs.spatie.be/laravel-activitylog/v1/advanced-usage/logging-model-events).
 
 ```php
 $newsItem->name = 'updated name';


### PR DESCRIPTION
Convert the URL in Event Logging example from github to https://docs.spatie.be/laravel-activitylog/v1/advanced-usage/logging-model-events since the original one would 404.