### PR TITLE
String based primaryKey values on Models don't get into the subject_id

### DIFF
--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -14,7 +14,7 @@ class CreateActivityLogTable extends Migration
             $table->increments('id');
             $table->string('log_name')->nullable();
             $table->string('description');
-            $table->integer('subject_id')->nullable();
+            $table->string('subject_id')->nullable();
             $table->string('subject_type')->nullable();
             $table->integer('causer_id')->nullable();
             $table->string('causer_type')->nullable();

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -4,18 +4,26 @@ namespace Spatie\Activitylog\Test;
 
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\Article;
+use Spatie\Activitylog\Test\Models\Category;
 use Spatie\Activitylog\Traits\LogsActivity;
 
 class LogsActivityTest extends TestCase
 {
-    /** @var \Spatie\Activitylog\Test\Article|\Spatie\Activitylog\Traits\LogsActivity */
+    /** @var \Spatie\Activitylog\Test\Models\Article|\Spatie\Activitylog\Traits\LogsActivity */
     protected $article;
+
+    /** @var \Spatie\Activitylog\Test\Models\Category|\Spatie\Activitylog\Traits\LogsActivity */
+    protected $category;
 
     public function setUp()
     {
         parent::setUp();
 
         $this->article = new class() extends Article {
+            use LogsActivity;
+        };
+
+        $this->category = new class() extends Category {
             use LogsActivity;
         };
 
@@ -30,6 +38,21 @@ class LogsActivityTest extends TestCase
 
         $this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
         $this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+        $this->assertTrue(is_int($this->getLastActivity()->subject->id));
+        $this->assertFalse(is_string($this->getLastActivity()->subject->id));
+        $this->assertEquals('created', $this->getLastActivity()->description);
+    }
+
+    /** @test */
+    public function it_will_log_the_creation_of_the_model_with_alternative_primaryKey()
+    {
+        $category = $this->createCategory();
+        $this->assertCount(1, Activity::all());
+
+        $this->assertInstanceOf(get_class($this->category), $this->getLastActivity()->subject);
+        $this->assertEquals($category->uuid, $this->getLastActivity()->subject->uuid);
+        $this->assertTrue(is_string($this->getLastActivity()->subject->uuid));
+        $this->assertFalse(is_int($this->getLastActivity()->subject->uuid));
         $this->assertEquals('created', $this->getLastActivity()->description);
     }
 
@@ -45,6 +68,25 @@ class LogsActivityTest extends TestCase
 
         $this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
         $this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+        $this->assertTrue(is_int($this->getLastActivity()->subject->id));
+        $this->assertFalse(is_string($this->getLastActivity()->subject->id));
+        $this->assertEquals('updated', $this->getLastActivity()->description);
+    }
+
+    /** @test */
+    public function it_will_log_an_update_of_the_model_with_alternative_primaryKey()
+    {
+        $category = $this->createCategory();
+
+        $category->name = 'changed name';
+        $category->save();
+
+        $this->assertCount(2, Activity::all());
+
+        $this->assertInstanceOf(get_class($this->category), $this->getLastActivity()->subject);
+        $this->assertEquals($category->uuid, $this->getLastActivity()->subject->uuid);
+        $this->assertTrue(is_string($this->getLastActivity()->subject->uuid));
+        $this->assertFalse(is_int($this->getLastActivity()->subject->uuid));
         $this->assertEquals('updated', $this->getLastActivity()->description);
     }
 
@@ -147,5 +189,15 @@ class LogsActivityTest extends TestCase
         $article->save();
 
         return $article;
+    }
+
+    protected function createCategory(): Category
+    {
+        $category = new $this->category();
+        $category->uuid = uniqid();
+        $category->name = 'my category';
+        $category->save();
+
+        return $category;
     }
 }

--- a/tests/Models/Category.php
+++ b/tests/Models/Category.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Category extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'categories';
+    protected $primaryKey = 'uuid';
+    public $incrementing = false;
+
+    protected $fillable = ['uuid', 'name'];
+    protected $visible = ['uuid', 'name'];
+    protected $guarded = [];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Spatie\Activitylog\ActivitylogServiceProvider;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\Article;
+use Spatie\Activitylog\Test\Models\Category;
 use Spatie\Activitylog\Test\Models\User;
 
 abstract class TestCase extends OrchestraTestCase
@@ -59,6 +60,8 @@ abstract class TestCase extends OrchestraTestCase
 
         $this->createTables('articles', 'users');
         $this->seedModels(Article::class, User::class);
+        $this->createNonIncrementingTables('categories');
+        $this->seedNonIncrementingModels(Category::class);
     }
 
     protected function resetDatabase()
@@ -91,11 +94,33 @@ abstract class TestCase extends OrchestraTestCase
         });
     }
 
+    protected function createNonIncrementingTables(...$tableNames)
+    {
+        collect($tableNames)->each(function (string $tableName) {
+            $this->app['db']->connection()->getSchemaBuilder()->create($tableName, function (Blueprint $table) {
+                $table->string('uuid')->primary();
+                $table->string('name')->nullable();
+                $table->string('text')->nullable();
+                $table->timestamps();
+                $table->softDeletes();
+            });
+        });
+    }
+
     protected function seedModels(...$modelClasses)
     {
         collect($modelClasses)->each(function (string $modelClass) {
             foreach (range(1, 0) as $index) {
                 $modelClass::create(['name' => "name {$index}"]);
+            }
+        });
+    }
+
+    protected function seedNonIncrementingModels(...$modelClasses)
+    {
+        collect($modelClasses)->each(function (string $modelClass) {
+            foreach (range(1, 0) as $index) {
+                $modelClass::create(['uuid' => uniqid(), 'name' => "name {$index}"]);
             }
         });
     }


### PR DESCRIPTION
The subject_id column on the activity_log table is an integer so string based primary key values do not get added correctly for Model event logging.

I made a change to the migration but also added some tests to try to illustrate it but SQLite allows string values in integer fields anyway so I added the is_int and is_string checks also.

Changing the subject_id column to a string worked perfectly for me.