### PR TITLE
Add causer & subject scope

### DIFF
--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -58,4 +58,24 @@ class Activity extends Eloquent
 
         return $query->whereIn('log_name', $logNames);
     }
+
+    /**
+     * Scope a query to only include activities by a give causer.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeByCauser(Builder $query, $causer): Builder
+    {
+        return $query->where('causer_id', $causer->getKey());
+    }
+
+    /**
+     * Scope a query to only include activities for a give subject.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeForSubject(Builder $query, $subject): Builder
+    {
+        return $query->where('subject_id', $subject->getKey());
+    }
 }

--- a/tests/ActivityModelTest.php
+++ b/tests/ActivityModelTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Activitylog\Test;
 
 use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Test\Models\User;
 
 class ActivityModelTest extends TestCase
 {
@@ -46,5 +47,23 @@ class ActivityModelTest extends TestCase
 
         $this->assertEquals('log1', $activity->first()->log_name);
         $this->assertEquals('log2', $activity->last()->log_name);
+    }
+
+    /** @test */
+    public function it_provides_a_scope_to_get_log_items_for_a_specific_causer()
+    {
+        $causer = User::first();
+        $activity = Activity::byCauser($causer)->get();
+
+        $this->assertCount($causer->activity->count(), $activity);
+    }
+
+    /** @test */
+    public function it_provides_a_scope_to_get_log_items_for_a_specific_subject()
+    {
+        $subject = User::first();
+        $activity = Activity::forSubject($subject)->get();
+
+        $this->assertCount($subject->activity->count(), $activity);
     }
 }


### PR DESCRIPTION
Hey @freekmurze,

this should fix #58.

However I am not 100% sure about the `id`. How flexible should it be? I saw it used within the package, but what if the user changes the `id` field to something else? 

Also do we need another `where` condition for the `type` or do you think this is unnecessary?