### PR TITLE
Update the package name in the project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![StyleCI](https://styleci.io/repos/61802818/shield)](https://styleci.io/repos/61802818)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-activitylog.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-activitylog)
 
-The `spatie/laravel-activity` package provides easy to use functions to log the activities of the users of your app. It can also automatically log model events. All activity will be stored in the `activity_log` table.
+The `spatie/laravel-activitylog` package provides easy to use functions to log the activities of the users of your app. It can also automatically log model events. All activity will be stored in the `activity_log` table.
 
 Here's a litte demo of how you can use it:
 


### PR DESCRIPTION
Initially I copied and pasted package name in the description assuming it was the correct string for composer but when the results were empty I later found the correct package name from line 93. Updating the package name in the description should save users that are sort of familiar with the package a little bit of time.