### PR TITLE
Bugfix SoftDeletes logging. Issue #85

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -95,6 +95,7 @@ trait LogsActivity
             //do not log update event if only ignored attributes are changed
             return (bool) count(array_except($this->getDirty(), $this->attributesToBeIgnored()));
         }
+
         return true;
     }
 }

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -100,26 +100,6 @@ class LogsActivityTest extends TestCase
     }
 
     /** @test */
-    public function it_will_log_the_force_deleting_of_a_model_with_softdeletes()
-    {
-        $article = $this->createArticle();
-
-        $article->delete();
-
-        $this->assertTrue($article->trashed());
-
-        $article = null;
-        $article = $this->article::onlyTrashed()->firstOrFail();
-        $article->forceDelete();
-
-        $this->assertCount(3, Activity::all());
-
-        $this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
-        $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
-        $this->assertEquals('force-deleted', $this->getLastActivity()->description);
-    }
-
-    /** @test */
     public function it_can_fetch_all_activity_for_a_model()
     {
         $article = $this->createArticle();

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -84,6 +84,42 @@ class LogsActivityTest extends TestCase
     }
 
     /** @test */
+    public function it_will_log_the_restoring_of_a_model_with_softdeletes()
+    {
+        $article = $this->createArticle();
+
+        $article->delete();
+
+        $article->restore();
+
+        $this->assertCount(3, Activity::all());
+
+        $this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
+        $this->assertEquals('restored', $this->getLastActivity()->description);
+    }
+
+    /** @test */
+    public function it_will_log_the_force_deleting_of_a_model_with_softdeletes()
+    {
+        $article = $this->createArticle();
+
+        $article->delete();
+
+        $this->assertTrue($article->trashed());
+
+        $article = null;
+        $article = $this->article::onlyTrashed()->firstOrFail();
+        $article->forceDelete();
+
+        $this->assertCount(3, Activity::all());
+
+        $this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
+        $this->assertEquals('force-deleted', $this->getLastActivity()->description);
+    }
+
+    /** @test */
     public function it_can_fetch_all_activity_for_a_model()
     {
         $article = $this->createArticle();


### PR DESCRIPTION
- added logging of `restored` event in classes that use the SoftDeletes trait
- `updated` event is no longer logged if model is just `restored`
- changed description if `deleted` event is fired by `forceDelete()` method