### PR TITLE
Add installation note regarding non-numeric model IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ You can publish the migration with:
 php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="migrations"
 ```
 
+*Note*: The default migration assumes you are using integers for your model IDs. If you are using UUIDs, or some other format, adjust the format of the subject_id and causer_id fields in the published migration before continuing.
+
 After the migration has been published you can create the `activity_log` table by running the migrations:
 
 


### PR DESCRIPTION
The migration published during installation assumes that model IDs are integer fields (related #69). This causes issues when used on a project where IDs aren't numeric, e.g. UUIDs or similar. While this is easy to resolve, it would be helpful if this was noted in the installation instructions. 

This PR adds a short note advising people to review/modify the published migration before running where they have non-numeric model IDs.