### PR TITLE
Fix scopeCausedBy() in Activity model.

### DIFF
--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -61,7 +61,7 @@ class Activity extends Eloquent
     }
 
     /**
-     * Scope a query to only include activities by a give causer.
+     * Scope a query to only include activities by a given causer.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
      * @param \Illuminate\Database\Eloquent\Model $causer
@@ -70,7 +70,9 @@ class Activity extends Eloquent
      */
     public function scopeCausedBy(Builder $query, Model $causer): Builder
     {
-        return $query->where('causer_id', $causer->getKey());
+        return $query
+            ->where('causer_type', get_class($causer))
+            ->where('causer_id', $causer->getKey());
     }
 
     /**

--- a/tests/ActivityModelTest.php
+++ b/tests/ActivityModelTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Activitylog\Test;
 
 use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Test\Models\Article;
 use Spatie\Activitylog\Test\Models\User;
 
 class ActivityModelTest extends TestCase
@@ -52,10 +53,20 @@ class ActivityModelTest extends TestCase
     /** @test */
     public function it_provides_a_scope_to_get_log_items_for_a_specific_causer()
     {
+        $subject = Article::first();
         $causer = User::first();
-        $activity = Activity::causedBy($causer)->get();
 
-        $this->assertCount($causer->activity->count(), $activity);
+        activity()->on($subject)->by($causer)->log('Foo');
+        activity()->on($subject)->by(User::create([
+            'name' => 'Another User'])
+        )->log('Bar');
+
+        $activities = Activity::causedBy($causer)->get();
+
+        $this->assertCount(1, $activities);
+        $this->assertEquals($causer->getKey(), $activities->first()->causer_id);
+        $this->assertEquals(get_class($causer), $activities->first()->causer_type);
+        $this->assertEquals('Foo', $activities->first()->description);
     }
 
     /** @test */

--- a/tests/ActivityModelTest.php
+++ b/tests/ActivityModelTest.php
@@ -58,8 +58,8 @@ class ActivityModelTest extends TestCase
 
         activity()->on($subject)->by($causer)->log('Foo');
         activity()->on($subject)->by(User::create([
-            'name' => 'Another User'])
-        )->log('Bar');
+            'name' => 'Another User',
+        ]))->log('Bar');
 
         $activities = Activity::causedBy($causer)->get();
 


### PR DESCRIPTION
`Activity::scopeCausedBy()` suffers from the same problem as `scopeForSubject()` brought in #89 - activities should be filtered by both `causer_type` and `causer_id`.