### PR TITLE
Activity Model and Laravel Aliases/Facades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.idea

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ Next, you must install the service provider:
 ];
 ```
 
+If you wish, you can also register the facade:
+
+```php
+// config/app.php
+'aliases' => [
+    ...
+    'Activity' => Spatie\Activitylog\ActivitylogFacade::class,
+];
+```
+
 You can publish the migration with:
 ```bash
 php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="migrations"

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -6,7 +6,6 @@ use Illuminate\Auth\AuthManager;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
-use Spatie\Activitylog\Exceptions\InvalidConfiguration;
 use Spatie\Activitylog\Models\Activity;
 
 class ActivityLogger

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -117,9 +117,7 @@ class ActivityLogger
             return;
         }
 
-        $activityModelClassName = $this->determineActivityModel();
-
-        $activity = new $activityModelClassName();
+        $activity = ActivitylogServiceProvider::getActivityModelInstance();
 
         if ($this->performedOn) {
             $activity->subject()->associate($this->performedOn);
@@ -181,19 +179,4 @@ class ActivityLogger
         }, $description);
     }
 
-    /**
-     * @throws \Spatie\Activitylog\Exceptions\InvalidConfiguration
-     *
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public function determineActivityModel()
-    {
-        $activityModel = config('laravel-activitylog.activity_model') ?? Activity::class;
-
-        if (! is_a($activityModel, Activity::class, true)) {
-            throw InvalidConfiguration::modelIsNotValid($activityModel);
-        }
-
-        return $activityModel;
-    }
 }

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -177,5 +177,4 @@ class ActivityLogger
             return array_get($attributeValue, $propertyName, $match);
         }, $description);
     }
-
 }

--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -34,9 +34,9 @@ class ActivitylogServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind(
-            'laravel-activitylog', function($app) {
+            'laravel-activitylog', function ($app) {
                 return self::getActivityModelInstance();
-        });
+            });
 
         $this->app->bind('command.activitylog:clean', CleanActivitylogCommand::class);
 

--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -35,7 +35,7 @@ class ActivitylogServiceProvider extends ServiceProvider
     {
         $this->app->bind(
             'laravel-activitylog', function($app) {
-            return self::getActivityModelInstance();
+                return self::getActivityModelInstance();
         });
 
         $this->app->bind('command.activitylog:clean', CleanActivitylogCommand::class);
@@ -50,7 +50,7 @@ class ActivitylogServiceProvider extends ServiceProvider
      *
      * @return \Illuminate\Database\Eloquent\Model
      */
-    static public function determineActivityModel()
+    public static function determineActivityModel()
     {
         $activityModel = config('laravel-activitylog.activity_model') != null ?
             config('laravel-activitylog.activity_model') :
@@ -63,7 +63,7 @@ class ActivitylogServiceProvider extends ServiceProvider
         return $activityModel;
     }
 
-    static public function getActivityModelInstance()
+    public static function getActivityModelInstance()
     {
         $activityModelClassName = self::determineActivityModel();
 

--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Spatie\Activitylog;
 
 use Illuminate\Support\ServiceProvider;
+use Spatie\Activitylog\Exceptions\InvalidConfiguration;
+use Spatie\Activitylog\Models\Activity;
 
 class ActivitylogServiceProvider extends ServiceProvider
 {
@@ -32,14 +34,39 @@ class ActivitylogServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind(
-            'laravel-activitylog',
-            \Spatie\Activitylog\ActivityLogger::class
-        );
+            'laravel-activitylog', function($app) {
+            return self::getActivityModelInstance();
+        });
 
         $this->app->bind('command.activitylog:clean', CleanActivitylogCommand::class);
 
         $this->commands([
             'command.activitylog:clean',
         ]);
+    }
+
+    /**
+     * @throws \Spatie\Activitylog\Exceptions\InvalidConfiguration
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    static public function determineActivityModel()
+    {
+        $activityModel = config('laravel-activitylog.activity_model') != null ?
+            config('laravel-activitylog.activity_model') :
+            Activity::class;
+
+        if (! is_a($activityModel, Activity::class, true)) {
+            throw InvalidConfiguration::modelIsNotValid($activityModel);
+        }
+
+        return $activityModel;
+    }
+
+    static public function getActivityModelInstance()
+    {
+        $activityModelClassName = self::determineActivityModel();
+
+        return new $activityModelClassName();
     }
 }

--- a/src/CleanActivitylogCommand.php
+++ b/src/CleanActivitylogCommand.php
@@ -4,7 +4,6 @@ namespace Spatie\Activitylog;
 
 use Carbon\Carbon;
 use Illuminate\Console\Command;
-use Spatie\Activitylog\Models\Activity;
 
 class CleanActivitylogCommand extends Command
 {
@@ -30,7 +29,9 @@ class CleanActivitylogCommand extends Command
 
         $cutOffDate = Carbon::now()->subDays($maxAgeInDays)->format('Y-m-d H:i:s');
 
-        $amountDeleted = Activity::where('created_at', '<', $cutOffDate)->delete();
+        $activity = ActivitylogServiceProvider::getActivityModelInstance();
+
+        $amountDeleted = $activity::where('created_at', '<', $cutOffDate)->delete();
 
         $this->info("Deleted {$amountDeleted} record(s) from the activity log.");
 

--- a/src/Traits/CausesActivity.php
+++ b/src/Traits/CausesActivity.php
@@ -3,13 +3,14 @@
 namespace Spatie\Activitylog\Traits;
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Spatie\Activitylog\ActivitylogServiceProvider;
 use Spatie\Activitylog\Models\Activity;
 
 trait CausesActivity
 {
     public function activity(): MorphMany
     {
-        return $this->morphMany(Activity::class, 'causer');
+        return $this->morphMany(ActivitylogServiceProvider::determineActivityModel(), 'causer');
     }
 
     /** @deprecated Use activity() instead */

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\ActivityLogger;
+use Spatie\Activitylog\ActivitylogServiceProvider;
 use Spatie\Activitylog\Models\Activity;
 
 trait LogsActivity
@@ -39,7 +40,7 @@ trait LogsActivity
 
     public function activity(): MorphMany
     {
-        return $this->morphMany(Activity::class, 'subject');
+        return $this->morphMany(ActivitylogServiceProvider::determineActivityModel(), 'subject');
     }
 
     public function getDescriptionForEvent(string $eventName): string


### PR DESCRIPTION
I noticed some inconsistencies with the use of the Activity model. While the user is able to define a custom 'activity_model' in the config file this information is not used by all of the laravel-activitylog classes. Instead, they default to the base Activity class. While this will work in most situations it makes it impossible for a user to reliably override any of the Activity class methods.

Additionally, I couldn't help but notice that the common practice of using Laravel Aliases/Facades for the Activity class was abandoned. A feature that many end-users have become accustom to and reliant upon.

This pull-request resolves the Activity class inheritance issue and also adds the feature of the Activity alias.
