### PR TITLE
Rename activity method to caused to avoid collision with LogsActivity…

### DIFF
--- a/src/Traits/CausesActivity.php
+++ b/src/Traits/CausesActivity.php
@@ -7,7 +7,7 @@ use Spatie\Activitylog\Models\Activity;
 
 trait CausesActivity
 {
-    public function activity(): MorphMany
+    public function caused(): MorphMany
     {
         return $this->morphMany(Activity::class, 'causer');
     }
@@ -15,6 +15,6 @@ trait CausesActivity
     /** @deprecated Use activity() instead */
     public function loggedActivity(): MorphMany
     {
-        return $this->activity();
+        return $this->caused();
     }
 }

--- a/tests/CausesActivityTest.php
+++ b/tests/CausesActivityTest.php
@@ -14,6 +14,6 @@ class CausesActivityTest extends TestCase
         activity()->by($causer)->log('perform activity');
         activity()->by($causer)->log('perform another activity');
 
-        $this->assertCount(2, $causer->activity);
+        $this->assertCount(2, $causer->caused);
     }
 }


### PR DESCRIPTION
I've renamed the method activity() on CausesActivity trait to caused() to avoid collision with the activity() method on LogsActivity trait.

This allows the use of both traits on the same Model, v. gr.: If you want to track modifications on the user model done by other users, usually admins.

P.S.: Thanks for this awesome package!