### PR TITLE
Restore Laravel 5.1 LTS compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,16 +26,16 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/config": "~5.2.0|~5.3.0",
-        "illuminate/database": "~5.2.6|~5.3.0",
-        "illuminate/support": "~5.2.0|~5.3.0",
+        "illuminate/config": "~5.1.0|~5.2.0|~5.3.0",
+        "illuminate/database": "~5.1.0|~5.2.6|~5.3.0",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0",
         "spatie/string": "^2.1"
 
     },
     "require-dev": {
         "phpunit/phpunit": "5.*",
-        "orchestra/testbench": "3.3.x-dev",
-        "orchestra/database": "3.3.x-dev"
+        "orchestra/testbench": "~3.1.0|3.3.x-dev",
+        "orchestra/database": "~3.1.0|3.3.x-dev"
     },
     "autoload": {
         "psr-4": {
@@ -50,6 +50,7 @@
             "Spatie\\Activitylog\\Test\\": "tests"
         }
     },
+
     "scripts": {
         "test": "vendor/bin/phpunit"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,16 +26,16 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/config": "~5.1.0|~5.2.0|~5.3.0",
-        "illuminate/database": "~5.1.0|~5.2.6|~5.3.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0",
+        "illuminate/config": "~5.1.24|~5.2.0|~5.3.0",
+        "illuminate/database": "~5.1.24|~5.2.6|~5.3.0",
+        "illuminate/support": "~5.1.24|~5.2.0|~5.3.0",
         "spatie/string": "^2.1"
 
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*",
-        "orchestra/testbench": "~3.1.0|3.3.x-dev",
-        "orchestra/database": "~3.1.0|3.3.x-dev"
+        "phpunit/phpunit": "~5.2",
+        "orchestra/testbench": "~3.1.2|3.3.x-dev",
+        "orchestra/database": "~3.1.2|3.3.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/config/laravel-activitylog.php
+++ b/config/laravel-activitylog.php
@@ -28,7 +28,7 @@ return [
     /*
      * If set to true, the subject returns soft deleted models.
      */
-     'subject_returns_soft_deleted_models' => false,
+    'subject_returns_soft_deleted_models' => false,
 
     /*
      * This model will be used to log activity. The only requirement is that

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -38,7 +38,11 @@ class ActivityLogger
 
         $authDriver = $config['laravel-activitylog']['default_auth_driver'] ?? $auth->getDefaultDriver();
 
-        $this->causedBy = $auth->guard($authDriver)->user();
+        if (starts_with(app()->version(), '5.1')) {
+            $this->causedBy = $auth->driver($authDriver)->user();
+        } else {
+            $this->causedBy = $auth->guard($authDriver)->user();
+        }
 
         $this->logName = $config['laravel-activitylog']['default_log_name'];
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,7 +46,11 @@ abstract class TestCase extends OrchestraTestCase
             'prefix'   => '',
         ]);
 
-        $app['config']->set('auth.providers.users.model', User::class);
+        if (starts_with($app->version(), '5.1')) {
+            $app['config']->set('auth.model', User::class);
+        } else {
+            $app['config']->set('auth.providers.users.model', User::class);
+        }
 
         $app['config']->set('app.key', '6rE9Nz59bGRbeMATftriyQjrpF7DcOQm');
     }


### PR DESCRIPTION
Tying this again...  I believe it really is this simple, it is working fine for me.  All tests are passing under 5.1 (have to force composer to install it—it looks like it is possible to automate this in Travis.)

Please let me know if you can think of anything I've missed here.