### PR TITLE
Changed Activity to extend Model instead of Eloquent.

### DIFF
--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -2,13 +2,12 @@
 
 namespace Spatie\Activitylog\Models;
 
-use Eloquent;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class Activity extends Eloquent
+class Activity extends Model
 {
     protected $table = 'activity_log';
 


### PR DESCRIPTION
Switched from extending the aliased `Eloquent` to extending `Model` as it is already included and will allow this package to be used in applications other than Laravel.