### PR TITLE
Change subject_id to string for non-integer primary keys

### DIFF
--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -14,7 +14,7 @@ class CreateActivityLogTable extends Migration
             $table->increments('id');
             $table->string('log_name')->nullable();
             $table->string('description');
-            $table->integer('subject_id')->nullable();
+            $table->string('subject_id')->nullable();
             $table->string('subject_type')->nullable();
             $table->integer('causer_id')->nullable();
             $table->string('causer_type')->nullable();


### PR DESCRIPTION
I have a couple of models where the primary key is not an ID, but a string (my settings table, to be exact). Trying to use the LogsActivity trait on this model causes an SQL error, as the primary key is not castable to an integer.

I don't know whether this has other consequences, but simply changing the database field type works in my application.