### PR TITLE
Ignore requested replacement if attribute is empty

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -184,6 +184,10 @@ class ActivityLogger
 
             $attributeValue = $activity->$attribute;
 
+            if (empty($attributeValue)) {
+                return $match;
+            }
+
             $attributeValue = $attributeValue->toArray();
 
             return array_get($attributeValue, $propertyName, $match);

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -176,6 +176,32 @@ class LogsActivityTest extends TestCase
         $this->assertEquals('created', $this->getLastActivity()->description);
     }
 
+    /** @test */
+    public function it_will_not_fail_if_asked_to_replace_from_empty_attribute()
+    {
+        $model = new class() extends Article {
+            use LogsActivity;
+            use SoftDeletes;
+            public function getDescriptionForEvent(string $eventName): string
+            {
+                return ":causer.name $eventName";
+            }
+        };
+
+        $entity = new $model();
+        $entity->save();
+        $entity->name = 'my name';
+        $entity->save();
+
+        $activities = $entity->activity;
+
+        $this->assertCount(2, $activities);
+        $this->assertEquals($entity->id, $activities[0]->subject->id);
+        $this->assertEquals($entity->id, $activities[1]->subject->id);
+        $this->assertEquals(':causer.name created', $activities[0]->description);
+        $this->assertEquals(':causer.name updated', $activities[1]->description);
+    }
+
     protected function createArticle(): Article
     {
         $article = new $this->article();


### PR DESCRIPTION
An alternative solution to #134.

When a replacement is requested for an empty attribute this makes the code ignore the replacement, and output the original text - ie the same behaviour if the attribute name isn't in the valid list (See https://github.com/leewillis77/laravel-activitylog/blob/master/src/ActivityLogger.php#L179)

In my test case, this means that the activity record is created with a description of:

`description: " :causer.name liked the walk "All three!"",`

E.g. :causer.name gets passed through as is. 

Feel free to accept whichever PR you prefer and reject the other, although this is probably my preferred option. 