### PR TITLE
Throw exception if attribute cannot be deferenced for string replacement

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -8,6 +8,7 @@ use Spatie\Activitylog\Models\Activity;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Config\Repository;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
+use Spatie\Activitylog\Exceptions\InvalidConfiguration;
 
 class ActivityLogger
 {
@@ -183,6 +184,12 @@ class ActivityLogger
             $propertyName = substr($match, strpos($match, '.') + 1);
 
             $attributeValue = $activity->$attribute;
+
+            if (empty($attributeValue)) {
+                throw new InvalidConfiguration(
+                    "Attempting to replace $match, but no attribute to use for placeholder."
+                );
+            }
 
             $attributeValue = $attributeValue->toArray();
 


### PR DESCRIPTION
Following on from #134, this is one option for resolving the issue.

This makes the code throw an Exception rather than a PHP error. I used Spatie\Activitylog\Exceptions\InvalidConfiguration since that seemed relevant - let me know if you'd prefer a different, or new exception type.

I've got an alternative PR for the issue which has a different approach. Feel free to except whichever you prefer and reject the other.  