### PR TITLE
Fixed saving new related model values

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -38,7 +38,7 @@ trait DetectsChanges
             return [];
         }
 
-        $properties['attributes'] = static::logChanges($this->fresh() ?? $this);
+        $properties['attributes'] = static::logChanges($this->exists ? $this->fresh() : $this);
 
         if (static::eventsToBeRecorded()->contains('updated') && $processingEvent == 'updated') {
             $nullProperties = array_fill_keys(array_keys($properties['attributes']), null);

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -38,7 +38,7 @@ trait DetectsChanges
             return [];
         }
 
-        $properties['attributes'] = static::logChanges($this);
+        $properties['attributes'] = static::logChanges($this->fresh() ?? $this);
 
         if (static::eventsToBeRecorded()->contains('updated') && $processingEvent == 'updated') {
             $nullProperties = array_fill_keys(array_keys($properties['attributes']), null);

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -112,7 +112,7 @@ class DetectsChangesTest extends TestCase
             use LogsActivity;
         };
 
-        $aUser = User::create([
+        $user = User::create([
             'name' => 'a name',
         ]);
 
@@ -123,10 +123,10 @@ class DetectsChangesTest extends TestCase
         $article = $articleClass::create([
             'name' => 'name',
             'text' => 'text',
-            'user_id' => $aUser->id,
+            'user_id' => $user->id,
         ]);
 
-        $article->User()->associate($anotherUser)->save();
+        $article->user()->associate($anotherUser)->save();
 
         $expectedChanges = [
             'attributes' => [

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -33,6 +33,7 @@ class DetectsChangesTest extends TestCase
         $expectedChanges = [
             'attributes' => [
                 'name' => 'my name',
+                'text' => null,
             ],
         ];
 
@@ -96,6 +97,47 @@ class DetectsChangesTest extends TestCase
             'old' => [
                 'name' => 'my name',
                 'text' => null,
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes->toArray());
+    }
+
+    /** @test */
+    public function it_can_store_the_changes_when_updating_a_related_model()
+    {
+        $articleClass = new class() extends Article {
+            static $logAttributes = ['name', 'text', 'user.name'];
+
+            use LogsActivity;
+        };
+
+        $aUser = User::create([
+            'name' => 'a name',
+        ]);
+
+        $anotherUser = User::create([
+            'name' => 'another name',
+        ]);
+
+        $article = $articleClass::create([
+            'name' => 'name',
+            'text' => 'text',
+            'user_id' => $aUser->id,
+        ]);
+
+        $article->User()->associate($anotherUser)->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'name' => 'name',
+                'text' => 'text',
+                'user.name' => 'another name',
+            ],
+            'old' => [
+                'name' => 'name',
+                'text' => 'text',
+                'user.name' => 'a name',
             ],
         ];
 


### PR DESCRIPTION
The new model relation support is a great addition to laravel acitivitylog. However, we noticed some unexpected behaviour in the changelog we're eager to see fixed:

When a related model is saved to the activity log, it's values are not refreshed. For instance, if you were to assign a user to an article, and subsequently, assign another user to it, the activity log would look like this:

```php
$changes = [
    'attributes' => [
        'name' => 'name',
        'text' => 'text',
        'user.name' => 'a name', // <= still the old user
    ],
    'old' => [
        'name' => 'name',
        'text' => 'text',
        'user.name' => 'a name', // <= old user
    ],
];
```

Laravel doesn't appear to refresh the eager loaded relations automatically. This PR adds a "refresh request" as well as a test to verify its behaviour. The changes array will now look like this:

```php
$changes = [
    'attributes' => [
        'name' => 'name',
        'text' => 'text',
        'user.name' => 'another name', // <= new user
    ],
    'old' => [
        'name' => 'name',
        'text' => 'text',
        'user.name' => 'a name', // <= old user
    ],
];
```


