### PR TITLE
create index on log_name

### DIFF
--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -20,6 +20,8 @@ class CreateActivityLogTable extends Migration
             $table->string('causer_type')->nullable();
             $table->text('properties')->nullable();
             $table->timestamps();
+
+            $table->index('log_name');
         });
     }
 


### PR DESCRIPTION
The `log_name` is universally used to differentiate logs. So creating an index to accelerate the query is necessary.