### PR TITLE
Re-add support for Laravel 5.1 LTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/config": "~5.3.0|~5.4.0",
-        "illuminate/database": "~5.3.0|~5.4.0",
-        "illuminate/support": "~5.3.0|~5.4.0",
+        "illuminate/config": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "illuminate/database": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
         "spatie/string": "^2.1"
 
     },

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -79,6 +79,7 @@ trait DetectsChanges
                 $changes += collect($model)->only($attribute);
             }
         }
+
         return $changes;
     }
 

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -71,15 +71,15 @@ trait DetectsChanges
 
     public static function logChanges(Model $model): array
     {
-        return collect($model->attributesToBeLogged())->mapWithKeys(
-            function ($attribute) use ($model) {
-                if (str_contains($attribute, '.')) {
-                    return self::getRelatedModelAttributeValue($model, $attribute);
-                }
-
-                return collect($model)->only($attribute);
+        $changes = [];
+        foreach ($model->attributesToBeLogged() as $attribute) {
+            if (str_contains($attribute, '.')) {
+                $changes += self::getRelatedModelAttributeValue($model, $attribute);
+            } else {
+                $changes += collect($model)->only($attribute);
             }
-        )->toArray();
+        }
+        return $changes;
     }
 
     protected static function getRelatedModelAttributeValue(Model $model, string $attribute): array


### PR DESCRIPTION
This re-adds support for Laravel 5.1 LTS initially added in #104 and then removed in #122 by replacing the one call to the `mapWithKeys` collection helper method with simply iterating over the initial array instead of performing a bunch of conversions to collections and back again.