### PR TITLE
Fix for when there is no 'web' guard

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -30,7 +30,7 @@ class ActivityLogger
     /** @var \Illuminate\Support\Collection */
     protected $properties;
 
-    /** @var \Illuminate\Support\Collection */
+    /** @var string */
     protected $authDriver;
 
     public function __construct(AuthManager $auth, Repository $config)

--- a/tests/ActivityloggerTest.php
+++ b/tests/ActivityloggerTest.php
@@ -100,6 +100,26 @@ class ActivityloggerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_log_an_activity_with_a_causer_when_there_is_no_web_guard()
+    {
+        config(['auth.guards.web' => null]);
+        config(['auth.guards.foo.driver' => 'session']);
+        config(['auth.guards.foo.provider' => 'users']);
+        config(['laravel-activitylog.default_auth_driver' => 'foo']);
+
+        $user = User::first();
+
+        activity()
+            ->causedBy($user)
+            ->log($this->activityDescription);
+
+        $firstActivity = Activity::first();
+
+        $this->assertEquals($user->id, $firstActivity->causer->id);
+        $this->assertInstanceOf(User::class, $firstActivity->causer);
+    }
+
+    /** @test */
     public function it_can_log_activity_with_properties()
     {
         $properties = [

--- a/tests/ActivityloggerTest.php
+++ b/tests/ActivityloggerTest.php
@@ -103,7 +103,7 @@ class ActivityloggerTest extends TestCase
     public function it_can_log_an_activity_with_a_causer_when_there_is_no_web_guard()
     {
         config(['auth.guards.web' => null]);
-        config(['auth.guards.foo' => ['driver' => 'session', 'provider' => 'users']);
+        config(['auth.guards.foo' => ['driver' => 'session', 'provider' => 'users']]);
         config(['laravel-activitylog.default_auth_driver' => 'foo']);
 
         $user = User::first();

--- a/tests/ActivityloggerTest.php
+++ b/tests/ActivityloggerTest.php
@@ -103,8 +103,7 @@ class ActivityloggerTest extends TestCase
     public function it_can_log_an_activity_with_a_causer_when_there_is_no_web_guard()
     {
         config(['auth.guards.web' => null]);
-        config(['auth.guards.foo.driver' => 'session']);
-        config(['auth.guards.foo.provider' => 'users']);
+        config(['auth.guards.foo' => ['driver' => 'session', 'provider' => 'users']);
         config(['laravel-activitylog.default_auth_driver' => 'foo']);
 
         $user = User::first();


### PR DESCRIPTION
If you have an application with no web guard, then the `normalizeCauser()` will not be able to get the User.