### PR TITLE
Can disable logging on demand

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -13,7 +13,7 @@ trait LogsActivity
 {
     use DetectsChanges;
 
-    private $withoutActivityLogging = false;
+    protected $enableLoggingModelsEvents = true;
 
     protected static function bootLogsActivity()
     {
@@ -40,14 +40,14 @@ trait LogsActivity
         });
     }
 
-    public function withoutActivityLogging() {
-		$this->withoutActivityLogging = true;
+    public function disableLogging() {
+		$this->enableLoggingModelsEvents = false;
 
     	return $this;
 	}
 
-    public function withActivityLogging() {
-    	$this->withoutActivityLogging = false;
+    public function enableLogging() {
+    	$this->enableLoggingModelsEvents = true;
 
     	return $this;
     }
@@ -100,7 +100,7 @@ trait LogsActivity
 
     protected function shouldLogEvent(string $eventName): bool
     {
-	    if ($this->withoutActivityLogging) {
+	    if (!$this->enableLoggingModelsEvents) {
 		    return false;
 	    }
 

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -2,12 +2,12 @@
 
 namespace Spatie\Activitylog\Traits;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\ActivityLogger;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\ActivitylogServiceProvider;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 trait LogsActivity
 {

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -5,7 +5,6 @@ namespace Spatie\Activitylog\Traits;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\ActivityLogger;
 use Illuminate\Database\Eloquent\Model;
-use Spatie\Activitylog\Models\Activity;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\ActivitylogServiceProvider;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -13,6 +12,8 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 trait LogsActivity
 {
     use DetectsChanges;
+
+    private $withoutActivityLogging = false;
 
     protected static function bootLogsActivity()
     {
@@ -38,6 +39,12 @@ trait LogsActivity
             });
         });
     }
+
+	public function withoutActivityLogging() {
+		$this->withoutActivityLogging = true;
+
+    	return $this;
+	}
 
     public function activity(): MorphMany
     {
@@ -87,6 +94,10 @@ trait LogsActivity
 
     protected function shouldLogEvent(string $eventName): bool
     {
+	    if ($this->withoutActivityLogging) {
+		    return false;
+	    }
+
         if (! in_array($eventName, ['created', 'updated'])) {
             return true;
         }

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -40,17 +40,17 @@ trait LogsActivity
         });
     }
 
-	public function withoutActivityLogging() {
+    public function withoutActivityLogging() {
 		$this->withoutActivityLogging = true;
 
     	return $this;
 	}
 
-	public function withActivityLogging() {
-		$this->withoutActivityLogging = false;
+    public function withActivityLogging() {
+    	$this->withoutActivityLogging = false;
 
     	return $this;
-	}
+    }
 
     public function activity(): MorphMany
     {

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -31,7 +31,11 @@ trait LogsActivity
                     return;
                 }
 
-                app(ActivityLogger::class)->useLog($logName)->performedOn($model)->withProperties($model->attributeValuesToBeLogged($eventName))->log($description);
+                app(ActivityLogger::class)
+                    ->useLog($logName)
+                    ->performedOn($model)
+                    ->withProperties($model->attributeValuesToBeLogged($eventName))
+                    ->log($description);
             });
         });
     }

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -46,6 +46,12 @@ trait LogsActivity
     	return $this;
 	}
 
+	public function withActivityLogging() {
+		$this->withoutActivityLogging = false;
+
+    	return $this;
+	}
+
     public function activity(): MorphMany
     {
         return $this->morphMany(ActivitylogServiceProvider::determineActivityModel(), 'subject');

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -2,12 +2,12 @@
 
 namespace Spatie\Activitylog\Traits;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\ActivityLogger;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\ActivitylogServiceProvider;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 trait LogsActivity
 {
@@ -31,25 +31,23 @@ trait LogsActivity
                     return;
                 }
 
-                app(ActivityLogger::class)
-                    ->useLog($logName)
-                    ->performedOn($model)
-                    ->withProperties($model->attributeValuesToBeLogged($eventName))
-                    ->log($description);
+                app(ActivityLogger::class)->useLog($logName)->performedOn($model)->withProperties($model->attributeValuesToBeLogged($eventName))->log($description);
             });
         });
     }
 
-    public function disableLogging() {
-		$this->enableLoggingModelsEvents = false;
+    public function disableLogging()
+    {
+        $this->enableLoggingModelsEvents = false;
 
-    	return $this;
-	}
+        return $this;
+    }
 
-    public function enableLogging() {
-    	$this->enableLoggingModelsEvents = true;
+    public function enableLogging()
+    {
+        $this->enableLoggingModelsEvents = true;
 
-    	return $this;
+        return $this;
     }
 
     public function activity(): MorphMany
@@ -100,9 +98,9 @@ trait LogsActivity
 
     protected function shouldLogEvent(string $eventName): bool
     {
-	    if (!$this->enableLoggingModelsEvents) {
-		    return false;
-	    }
+        if (! $this->enableLoggingModelsEvents) {
+            return false;
+        }
 
         if (! in_array($eventName, ['created', 'updated'])) {
             return true;

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -186,7 +186,7 @@ class LogsActivityTest extends TestCase
             }
         };
 
-        $article       = new $articleClass();
+        $article = new $articleClass();
         $article->name = 'my name';
         $article->save();
 
@@ -203,7 +203,7 @@ class LogsActivityTest extends TestCase
             protected static $ignoreChangedAttributes = ['text'];
         };
 
-        $article       = new $articleClass();
+        $article = new $articleClass();
         $article->name = 'my name';
         $article->save();
 
@@ -246,7 +246,7 @@ class LogsActivityTest extends TestCase
 
     protected function createArticle(): Article
     {
-        $article       = new $this->article();
+        $article = new $this->article();
         $article->name = 'my name';
         $article->save();
 

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Activitylog\Test;
 
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\Article;
 use Spatie\Activitylog\Traits\LogsActivity;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class LogsActivityTest extends TestCase
 {
@@ -16,8 +16,7 @@ class LogsActivityTest extends TestCase
     {
         parent::setUp();
 
-        $this->article = new class() extends Article
-        {
+        $this->article = new class() extends Article {
             use LogsActivity;
             use SoftDeletes;
         };
@@ -95,8 +94,7 @@ class LogsActivityTest extends TestCase
     /** @test */
     public function it_will_log_the_deletion_of_a_model_without_softdeletes()
     {
-        $articleClass = new class() extends Article
-        {
+        $articleClass = new class() extends Article {
             use LogsActivity;
         };
 
@@ -179,8 +177,7 @@ class LogsActivityTest extends TestCase
     /** @test */
     public function it_can_log_activity_to_log_named_in_the_model()
     {
-        $articleClass = new class() extends Article
-        {
+        $articleClass = new class() extends Article {
             use LogsActivity;
 
             public function getLogNameToUse()
@@ -200,8 +197,7 @@ class LogsActivityTest extends TestCase
     /** @test */
     public function it_will_not_log_an_update_of_the_model_if_only_ignored_attributes_are_changed()
     {
-        $articleClass = new class() extends Article
-        {
+        $articleClass = new class() extends Article {
             use LogsActivity;
 
             protected static $ignoreChangedAttributes = ['text'];
@@ -224,8 +220,7 @@ class LogsActivityTest extends TestCase
     /** @test */
     public function it_will_not_fail_if_asked_to_replace_from_empty_attribute()
     {
-        $model = new class() extends Article
-        {
+        $model = new class() extends Article {
             use LogsActivity;
             use SoftDeletes;
 

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -48,6 +48,25 @@ class LogsActivityTest extends TestCase
 	}
 
 	/** @test */
+	public function it_can_switch_on_activity_logging_after_disabling_it()
+	{
+		$article = new $this->article();
+
+		$article->withoutActivityLogging();
+		$article->name = 'my name';
+		$article->save();
+
+		$article->withActivityLogging();
+		$article->name = 'my new name';
+		$article->save();
+
+		$this->assertCount(1, Activity::all());
+		$this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
+		$this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+		$this->assertEquals('updated', $this->getLastActivity()->description);
+	}
+
+	/** @test */
 	public function it_can_skip_logging_if_asked_to_for_update_method()
 	{
 		$article = new $this->article();

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class LogsActivityTest extends TestCase
 {
 	/** @var \Spatie\Activitylog\Test\Article|\Spatie\Activitylog\Traits\LogsActivity */
-	protected $article;
+    protected $article;
 
 	public function setUp()
 	{
@@ -39,7 +39,7 @@ class LogsActivityTest extends TestCase
 	public function it_can_skip_logging_model_events_if_asked_to()
 	{
 		$article = new $this->article();
-		$article->withoutActivityLogging();
+		$article->disableLogging();
 		$article->name = 'my name';
 		$article->save();
 
@@ -52,11 +52,11 @@ class LogsActivityTest extends TestCase
 	{
 		$article = new $this->article();
 
-		$article->withoutActivityLogging();
+		$article->disableLogging();
 		$article->name = 'my name';
 		$article->save();
 
-		$article->withActivityLogging();
+		$article->enableLogging();
 		$article->name = 'my new name';
 		$article->save();
 
@@ -70,7 +70,7 @@ class LogsActivityTest extends TestCase
 	public function it_can_skip_logging_if_asked_to_for_update_method()
 	{
 		$article = new $this->article();
-		$article->withoutActivityLogging()->update(['name' => 'How to log events']);
+		$article->disableLogging()->update(['name' => 'How to log events']);
 
 		$this->assertCount(0, Activity::all());
 		$this->assertNull($this->getLastActivity());

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -16,24 +16,23 @@ class LogsActivityTest extends TestCase
 	{
 		parent::setUp();
 
-		$this->article = new class() extends Article
-		{
+		$this->article = new class() extends Article {
 			use LogsActivity;
 			use SoftDeletes;
 		};
 
-		$this->assertCount( 0, Activity::all() );
+		$this->assertCount(0, Activity::all());
 	}
 
 	/** @test */
 	public function it_will_log_the_creation_of_the_model()
 	{
 		$article = $this->createArticle();
-		$this->assertCount( 1, Activity::all() );
+		$this->assertCount(1, Activity::all());
 
-		$this->assertInstanceOf( get_class( $this->article ), $this->getLastActivity()->subject );
-		$this->assertEquals( $article->id, $this->getLastActivity()->subject->id );
-		$this->assertEquals( 'created', $this->getLastActivity()->description );
+		$this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
+		$this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+		$this->assertEquals('created', $this->getLastActivity()->description);
 	}
 
 	/** @test */
@@ -52,10 +51,10 @@ class LogsActivityTest extends TestCase
 	public function it_can_skip_logging_if_asked_to_for_update_method()
 	{
 		$article = new $this->article();
-		$article->withoutActivityLogging()->update( [ 'name' => 'How to log events' ] );
+		$article->withoutActivityLogging()->update(['name' => 'How to log events']);
 
-		$this->assertCount( 0, Activity::all() );
-		$this->assertNull( $this->getLastActivity() );
+		$this->assertCount(0, Activity::all());
+		$this->assertNull($this->getLastActivity());
 	}
 
 	/** @test */
@@ -66,18 +65,17 @@ class LogsActivityTest extends TestCase
 		$article->name = 'changed name';
 		$article->save();
 
-		$this->assertCount( 2, Activity::all() );
+		$this->assertCount(2, Activity::all());
 
-		$this->assertInstanceOf( get_class( $this->article ), $this->getLastActivity()->subject );
-		$this->assertEquals( $article->id, $this->getLastActivity()->subject->id );
-		$this->assertEquals( 'updated', $this->getLastActivity()->description );
+		$this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
+		$this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+		$this->assertEquals('updated', $this->getLastActivity()->description);
 	}
 
 	/** @test */
 	public function it_will_log_the_deletion_of_a_model_without_softdeletes()
 	{
-		$articleClass = new class() extends Article
-		{
+		$articleClass = new class() extends Article {
 			use LogsActivity;
 		};
 
@@ -85,11 +83,11 @@ class LogsActivityTest extends TestCase
 
 		$article->save();
 
-		$this->assertEquals( 'created', $this->getLastActivity()->description );
+		$this->assertEquals('created', $this->getLastActivity()->description);
 
 		$article->delete();
 
-		$this->assertEquals( 'deleted', $this->getLastActivity()->description );
+		$this->assertEquals('deleted', $this->getLastActivity()->description);
 	}
 
 	/** @test */
@@ -99,11 +97,11 @@ class LogsActivityTest extends TestCase
 
 		$article->delete();
 
-		$this->assertCount( 2, Activity::all() );
+		$this->assertCount(2, Activity::all());
 
-		$this->assertEquals( get_class( $this->article ), $this->getLastActivity()->subject_type );
-		$this->assertEquals( $article->id, $this->getLastActivity()->subject_id );
-		$this->assertEquals( 'deleted', $this->getLastActivity()->description );
+		$this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
+		$this->assertEquals($article->id, $this->getLastActivity()->subject_id);
+		$this->assertEquals('deleted', $this->getLastActivity()->description);
 	}
 
 	/** @test */
@@ -115,11 +113,11 @@ class LogsActivityTest extends TestCase
 
 		$article->restore();
 
-		$this->assertCount( 3, Activity::all() );
+		$this->assertCount(3, Activity::all());
 
-		$this->assertEquals( get_class( $this->article ), $this->getLastActivity()->subject_type );
-		$this->assertEquals( $article->id, $this->getLastActivity()->subject_id );
-		$this->assertEquals( 'restored', $this->getLastActivity()->description );
+		$this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
+		$this->assertEquals($article->id, $this->getLastActivity()->subject_id);
+		$this->assertEquals('restored', $this->getLastActivity()->description);
 	}
 
 	/** @test */
@@ -132,13 +130,13 @@ class LogsActivityTest extends TestCase
 
 		$activities = $article->activity;
 
-		$this->assertCount( 2, $activities );
+		$this->assertCount(2, $activities);
 	}
 
 	/** @test */
 	public function it_can_fetch_soft_deleted_models()
 	{
-		$this->app['config']->set( 'laravel-activitylog.subject_returns_soft_deleted_models', true );
+		$this->app['config']->set('laravel-activitylog.subject_returns_soft_deleted_models', true);
 
 		$article = $this->createArticle();
 
@@ -149,19 +147,18 @@ class LogsActivityTest extends TestCase
 
 		$activities = $article->activity;
 
-		$this->assertCount( 3, $activities );
+		$this->assertCount(3, $activities);
 
-		$this->assertEquals( get_class( $this->article ), $this->getLastActivity()->subject_type );
-		$this->assertEquals( $article->id, $this->getLastActivity()->subject_id );
-		$this->assertEquals( 'deleted', $this->getLastActivity()->description );
-		$this->assertEquals( 'changed name', $this->getLastActivity()->subject->name );
+		$this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
+		$this->assertEquals($article->id, $this->getLastActivity()->subject_id);
+		$this->assertEquals('deleted', $this->getLastActivity()->description);
+		$this->assertEquals('changed name', $this->getLastActivity()->subject->name);
 	}
 
 	/** @test */
 	public function it_can_log_activity_to_log_named_in_the_model()
 	{
-		$articleClass = new class() extends Article
-		{
+		$articleClass = new class() extends Article {
 			use LogsActivity;
 
 			public function getLogNameToUse()
@@ -170,47 +167,45 @@ class LogsActivityTest extends TestCase
 			}
 		};
 
-		$article       = new $articleClass();
+		$article = new $articleClass();
 		$article->name = 'my name';
 		$article->save();
 
-		$this->assertEquals( $article->id, Activity::inLog( 'custom_log' )->first()->subject->id );
-		$this->assertCount( 1, Activity::inLog( 'custom_log' )->get() );
+		$this->assertEquals($article->id, Activity::inLog('custom_log')->first()->subject->id);
+		$this->assertCount(1, Activity::inLog('custom_log')->get());
 	}
 
 	/** @test */
 	public function it_will_not_log_an_update_of_the_model_if_only_ignored_attributes_are_changed()
 	{
-		$articleClass = new class() extends Article
-		{
+		$articleClass = new class() extends Article {
 			use LogsActivity;
 
-			protected static $ignoreChangedAttributes = [ 'text' ];
+			protected static $ignoreChangedAttributes = ['text'];
 		};
 
-		$article       = new $articleClass();
+		$article = new $articleClass();
 		$article->name = 'my name';
 		$article->save();
 
 		$article->text = 'ignore me';
 		$article->save();
 
-		$this->assertCount( 1, Activity::all() );
+		$this->assertCount(1, Activity::all());
 
-		$this->assertInstanceOf( get_class( $articleClass ), $this->getLastActivity()->subject );
-		$this->assertEquals( $article->id, $this->getLastActivity()->subject->id );
-		$this->assertEquals( 'created', $this->getLastActivity()->description );
+		$this->assertInstanceOf(get_class($articleClass), $this->getLastActivity()->subject);
+		$this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+		$this->assertEquals('created', $this->getLastActivity()->description);
 	}
 
 	/** @test */
 	public function it_will_not_fail_if_asked_to_replace_from_empty_attribute()
 	{
-		$model = new class() extends Article
-		{
+		$model = new class() extends Article {
 			use LogsActivity;
 			use SoftDeletes;
 
-			public function getDescriptionForEvent( string $eventName ): string
+			public function getDescriptionForEvent(string $eventName): string
 			{
 				return ":causer.name $eventName";
 			}
@@ -223,16 +218,16 @@ class LogsActivityTest extends TestCase
 
 		$activities = $entity->activity;
 
-		$this->assertCount( 2, $activities );
-		$this->assertEquals( $entity->id, $activities[0]->subject->id );
-		$this->assertEquals( $entity->id, $activities[1]->subject->id );
-		$this->assertEquals( ':causer.name created', $activities[0]->description );
-		$this->assertEquals( ':causer.name updated', $activities[1]->description );
+		$this->assertCount(2, $activities);
+		$this->assertEquals($entity->id, $activities[0]->subject->id);
+		$this->assertEquals($entity->id, $activities[1]->subject->id);
+		$this->assertEquals(':causer.name created', $activities[0]->description);
+		$this->assertEquals(':causer.name updated', $activities[1]->description);
 	}
 
 	protected function createArticle(): Article
 	{
-		$article       = new $this->article();
+		$article = new $this->article();
 		$article->name = 'my name';
 		$article->save();
 

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -2,254 +2,259 @@
 
 namespace Spatie\Activitylog\Test;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\Article;
 use Spatie\Activitylog\Traits\LogsActivity;
-use Illuminate\Database\Eloquent\SoftDeletes;
 
 class LogsActivityTest extends TestCase
 {
-	/** @var \Spatie\Activitylog\Test\Article|\Spatie\Activitylog\Traits\LogsActivity */
+    /** @var \Spatie\Activitylog\Test\Article|\Spatie\Activitylog\Traits\LogsActivity */
     protected $article;
 
-	public function setUp()
-	{
-		parent::setUp();
+    public function setUp()
+    {
+        parent::setUp();
 
-		$this->article = new class() extends Article {
-			use LogsActivity;
-			use SoftDeletes;
-		};
+        $this->article = new class() extends Article
+        {
+            use LogsActivity;
+            use SoftDeletes;
+        };
 
-		$this->assertCount(0, Activity::all());
-	}
+        $this->assertCount(0, Activity::all());
+    }
 
-	/** @test */
-	public function it_will_log_the_creation_of_the_model()
-	{
-		$article = $this->createArticle();
-		$this->assertCount(1, Activity::all());
+    /** @test */
+    public function it_will_log_the_creation_of_the_model()
+    {
+        $article = $this->createArticle();
+        $this->assertCount(1, Activity::all());
 
-		$this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
-		$this->assertEquals($article->id, $this->getLastActivity()->subject->id);
-		$this->assertEquals('created', $this->getLastActivity()->description);
-	}
+        $this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+        $this->assertEquals('created', $this->getLastActivity()->description);
+    }
 
-	/** @test */
-	public function it_can_skip_logging_model_events_if_asked_to()
-	{
-		$article = new $this->article();
-		$article->disableLogging();
-		$article->name = 'my name';
-		$article->save();
+    /** @test */
+    public function it_can_skip_logging_model_events_if_asked_to()
+    {
+        $article = new $this->article();
+        $article->disableLogging();
+        $article->name = 'my name';
+        $article->save();
 
-		$this->assertCount( 0, Activity::all() );
-		$this->assertNull( $this->getLastActivity() );
-	}
+        $this->assertCount(0, Activity::all());
+        $this->assertNull($this->getLastActivity());
+    }
 
-	/** @test */
-	public function it_can_switch_on_activity_logging_after_disabling_it()
-	{
-		$article = new $this->article();
+    /** @test */
+    public function it_can_switch_on_activity_logging_after_disabling_it()
+    {
+        $article = new $this->article();
 
-		$article->disableLogging();
-		$article->name = 'my name';
-		$article->save();
+        $article->disableLogging();
+        $article->name = 'my name';
+        $article->save();
 
-		$article->enableLogging();
-		$article->name = 'my new name';
-		$article->save();
+        $article->enableLogging();
+        $article->name = 'my new name';
+        $article->save();
 
-		$this->assertCount(1, Activity::all());
-		$this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
-		$this->assertEquals($article->id, $this->getLastActivity()->subject->id);
-		$this->assertEquals('updated', $this->getLastActivity()->description);
-	}
+        $this->assertCount(1, Activity::all());
+        $this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+        $this->assertEquals('updated', $this->getLastActivity()->description);
+    }
 
-	/** @test */
-	public function it_can_skip_logging_if_asked_to_for_update_method()
-	{
-		$article = new $this->article();
-		$article->disableLogging()->update(['name' => 'How to log events']);
+    /** @test */
+    public function it_can_skip_logging_if_asked_to_for_update_method()
+    {
+        $article = new $this->article();
+        $article->disableLogging()->update(['name' => 'How to log events']);
 
-		$this->assertCount(0, Activity::all());
-		$this->assertNull($this->getLastActivity());
-	}
+        $this->assertCount(0, Activity::all());
+        $this->assertNull($this->getLastActivity());
+    }
 
-	/** @test */
-	public function it_will_log_an_update_of_the_model()
-	{
-		$article = $this->createArticle();
+    /** @test */
+    public function it_will_log_an_update_of_the_model()
+    {
+        $article = $this->createArticle();
 
-		$article->name = 'changed name';
-		$article->save();
+        $article->name = 'changed name';
+        $article->save();
 
-		$this->assertCount(2, Activity::all());
+        $this->assertCount(2, Activity::all());
 
-		$this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
-		$this->assertEquals($article->id, $this->getLastActivity()->subject->id);
-		$this->assertEquals('updated', $this->getLastActivity()->description);
-	}
+        $this->assertInstanceOf(get_class($this->article), $this->getLastActivity()->subject);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+        $this->assertEquals('updated', $this->getLastActivity()->description);
+    }
 
-	/** @test */
-	public function it_will_log_the_deletion_of_a_model_without_softdeletes()
-	{
-		$articleClass = new class() extends Article {
-			use LogsActivity;
-		};
+    /** @test */
+    public function it_will_log_the_deletion_of_a_model_without_softdeletes()
+    {
+        $articleClass = new class() extends Article
+        {
+            use LogsActivity;
+        };
 
-		$article = new $articleClass();
+        $article = new $articleClass();
 
-		$article->save();
+        $article->save();
 
-		$this->assertEquals('created', $this->getLastActivity()->description);
+        $this->assertEquals('created', $this->getLastActivity()->description);
 
-		$article->delete();
+        $article->delete();
 
-		$this->assertEquals('deleted', $this->getLastActivity()->description);
-	}
+        $this->assertEquals('deleted', $this->getLastActivity()->description);
+    }
 
-	/** @test */
-	public function it_will_log_the_deletion_of_a_model_with_softdeletes()
-	{
-		$article = $this->createArticle();
+    /** @test */
+    public function it_will_log_the_deletion_of_a_model_with_softdeletes()
+    {
+        $article = $this->createArticle();
 
-		$article->delete();
+        $article->delete();
 
-		$this->assertCount(2, Activity::all());
+        $this->assertCount(2, Activity::all());
 
-		$this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
-		$this->assertEquals($article->id, $this->getLastActivity()->subject_id);
-		$this->assertEquals('deleted', $this->getLastActivity()->description);
-	}
+        $this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
+        $this->assertEquals('deleted', $this->getLastActivity()->description);
+    }
 
-	/** @test */
-	public function it_will_log_the_restoring_of_a_model_with_softdeletes()
-	{
-		$article = $this->createArticle();
+    /** @test */
+    public function it_will_log_the_restoring_of_a_model_with_softdeletes()
+    {
+        $article = $this->createArticle();
 
-		$article->delete();
+        $article->delete();
 
-		$article->restore();
+        $article->restore();
 
-		$this->assertCount(3, Activity::all());
+        $this->assertCount(3, Activity::all());
 
-		$this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
-		$this->assertEquals($article->id, $this->getLastActivity()->subject_id);
-		$this->assertEquals('restored', $this->getLastActivity()->description);
-	}
+        $this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
+        $this->assertEquals('restored', $this->getLastActivity()->description);
+    }
 
-	/** @test */
-	public function it_can_fetch_all_activity_for_a_model()
-	{
-		$article = $this->createArticle();
+    /** @test */
+    public function it_can_fetch_all_activity_for_a_model()
+    {
+        $article = $this->createArticle();
 
-		$article->name = 'changed name';
-		$article->save();
+        $article->name = 'changed name';
+        $article->save();
 
-		$activities = $article->activity;
+        $activities = $article->activity;
 
-		$this->assertCount(2, $activities);
-	}
+        $this->assertCount(2, $activities);
+    }
 
-	/** @test */
-	public function it_can_fetch_soft_deleted_models()
-	{
-		$this->app['config']->set('laravel-activitylog.subject_returns_soft_deleted_models', true);
+    /** @test */
+    public function it_can_fetch_soft_deleted_models()
+    {
+        $this->app['config']->set('laravel-activitylog.subject_returns_soft_deleted_models', true);
 
-		$article = $this->createArticle();
+        $article = $this->createArticle();
 
-		$article->name = 'changed name';
-		$article->save();
+        $article->name = 'changed name';
+        $article->save();
 
-		$article->delete();
+        $article->delete();
 
-		$activities = $article->activity;
+        $activities = $article->activity;
 
-		$this->assertCount(3, $activities);
+        $this->assertCount(3, $activities);
 
-		$this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
-		$this->assertEquals($article->id, $this->getLastActivity()->subject_id);
-		$this->assertEquals('deleted', $this->getLastActivity()->description);
-		$this->assertEquals('changed name', $this->getLastActivity()->subject->name);
-	}
+        $this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
+        $this->assertEquals('deleted', $this->getLastActivity()->description);
+        $this->assertEquals('changed name', $this->getLastActivity()->subject->name);
+    }
 
-	/** @test */
-	public function it_can_log_activity_to_log_named_in_the_model()
-	{
-		$articleClass = new class() extends Article {
-			use LogsActivity;
+    /** @test */
+    public function it_can_log_activity_to_log_named_in_the_model()
+    {
+        $articleClass = new class() extends Article
+        {
+            use LogsActivity;
 
-			public function getLogNameToUse()
-			{
-				return 'custom_log';
-			}
-		};
+            public function getLogNameToUse()
+            {
+                return 'custom_log';
+            }
+        };
 
-		$article = new $articleClass();
-		$article->name = 'my name';
-		$article->save();
+        $article       = new $articleClass();
+        $article->name = 'my name';
+        $article->save();
 
-		$this->assertEquals($article->id, Activity::inLog('custom_log')->first()->subject->id);
-		$this->assertCount(1, Activity::inLog('custom_log')->get());
-	}
+        $this->assertEquals($article->id, Activity::inLog('custom_log')->first()->subject->id);
+        $this->assertCount(1, Activity::inLog('custom_log')->get());
+    }
 
-	/** @test */
-	public function it_will_not_log_an_update_of_the_model_if_only_ignored_attributes_are_changed()
-	{
-		$articleClass = new class() extends Article {
-			use LogsActivity;
+    /** @test */
+    public function it_will_not_log_an_update_of_the_model_if_only_ignored_attributes_are_changed()
+    {
+        $articleClass = new class() extends Article
+        {
+            use LogsActivity;
 
-			protected static $ignoreChangedAttributes = ['text'];
-		};
+            protected static $ignoreChangedAttributes = ['text'];
+        };
 
-		$article = new $articleClass();
-		$article->name = 'my name';
-		$article->save();
+        $article       = new $articleClass();
+        $article->name = 'my name';
+        $article->save();
 
-		$article->text = 'ignore me';
-		$article->save();
+        $article->text = 'ignore me';
+        $article->save();
 
-		$this->assertCount(1, Activity::all());
+        $this->assertCount(1, Activity::all());
 
-		$this->assertInstanceOf(get_class($articleClass), $this->getLastActivity()->subject);
-		$this->assertEquals($article->id, $this->getLastActivity()->subject->id);
-		$this->assertEquals('created', $this->getLastActivity()->description);
-	}
+        $this->assertInstanceOf(get_class($articleClass), $this->getLastActivity()->subject);
+        $this->assertEquals($article->id, $this->getLastActivity()->subject->id);
+        $this->assertEquals('created', $this->getLastActivity()->description);
+    }
 
-	/** @test */
-	public function it_will_not_fail_if_asked_to_replace_from_empty_attribute()
-	{
-		$model = new class() extends Article {
-			use LogsActivity;
-			use SoftDeletes;
+    /** @test */
+    public function it_will_not_fail_if_asked_to_replace_from_empty_attribute()
+    {
+        $model = new class() extends Article
+        {
+            use LogsActivity;
+            use SoftDeletes;
 
-			public function getDescriptionForEvent(string $eventName): string
-			{
-				return ":causer.name $eventName";
-			}
-		};
+            public function getDescriptionForEvent(string $eventName): string
+            {
+                return ":causer.name $eventName";
+            }
+        };
 
-		$entity = new $model();
-		$entity->save();
-		$entity->name = 'my name';
-		$entity->save();
+        $entity = new $model();
+        $entity->save();
+        $entity->name = 'my name';
+        $entity->save();
 
-		$activities = $entity->activity;
+        $activities = $entity->activity;
 
-		$this->assertCount(2, $activities);
-		$this->assertEquals($entity->id, $activities[0]->subject->id);
-		$this->assertEquals($entity->id, $activities[1]->subject->id);
-		$this->assertEquals(':causer.name created', $activities[0]->description);
-		$this->assertEquals(':causer.name updated', $activities[1]->description);
-	}
+        $this->assertCount(2, $activities);
+        $this->assertEquals($entity->id, $activities[0]->subject->id);
+        $this->assertEquals($entity->id, $activities[1]->subject->id);
+        $this->assertEquals(':causer.name created', $activities[0]->description);
+        $this->assertEquals(':causer.name updated', $activities[1]->description);
+    }
 
-	protected function createArticle(): Article
-	{
-		$article = new $this->article();
-		$article->name = 'my name';
-		$article->save();
+    protected function createArticle(): Article
+    {
+        $article       = new $this->article();
+        $article->name = 'my name';
+        $article->save();
 
-		return $article;
-	}
+        return $article;
+    }
 }


### PR DESCRIPTION
I was working on a way to disable on `::create` however it proved to be harder than expected.

Please modify the code if you have any way of improving it and making it visually prettier to look at.

I've added 3 tests to support this.

## Usage

```php
$user = User::find(1);

// Example 1:
$user->withoutActivityLogging()->update(['name' => 'Testing']);

// Example 2:
$user->withoutActivityLogging();
$user->name = 'Testing';
$user->save();
```

### Re-enabling logging for same model

Should you want to enable logging again, I've added another method:

```php
$user = User::find(1);

// Disable
$user->withoutActivityLogging()->update(['name' => 'Not logged']);

// Enable
$user->withActivityLogging(); // with, not without
$user->name = 'Logged';
$user->save();
```