### PR TITLE
[LaraPackagePort] Prepare for 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,7 @@
     "name": "spatie/laravel-activitylog",
     "description": "A very simple activity logger to monitor the users of your website or application",
     "homepage": "https://github.com/spatie/activitylog",
-    "keywords":
-    [
+    "keywords": [
         "spatie",
         "log",
         "user",
@@ -25,17 +24,16 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
-        "illuminate/config": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/database": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "php": "^7.0",
+        "illuminate/config": "dev-master",
+        "illuminate/database": "dev-master",
+        "illuminate/support": "dev-master",
         "spatie/string": "^2.1"
-
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "orchestra/testbench": "~3.3.0|~3.4.0",
-        "orchestra/database": "~3.3.0|~3.4.0"
+        "phpunit/phpunit": "^6.0",
+        "orchestra/testbench": "dev-master",
+        "orchestra/database": "dev-master"
     },
     "autoload": {
         "psr-4": {
@@ -50,7 +48,6 @@
             "Spatie\\Activitylog\\Test\\": "tests"
         }
     },
-
     "scripts": {
         "test": "vendor/bin/phpunit"
     },
@@ -61,5 +58,12 @@
                 "Spatie\\Activitylog\\ActivitylogServiceProvider"
             ]
         }
+    },
+    "_before_require": {
+        "php": "^7.0",
+        "illuminate/config": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "illuminate/database": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "spatie/string": "^2.1"
     }
 }


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've testet it automated and this was the PHPUnit Result:PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-activitylog/phpunit.xml.dist

................E.......R.....................                    46 / 46 (100%)

Time: 16.56 seconds, Memory: 18.00MB

There was 1 error:

1) Spatie\Activitylog\Test\ActivityloggerTest::it_will_throw_an_exception_if_it_cannot_translate_a_causer_id
Error: Call to undefined method Spatie\Activitylog\Test\ActivityloggerTest::setExpectedException()

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-activitylog/tests/ActivityloggerTest.php:175

--

There was 1 risky test:

1) Spatie\Activitylog\Test\CustomActivityModelTest::it_does_not_throw_an_exception_when_model_config_is_null
This test did not perform any assertions

ERRORS!
Tests: 46, Assertions: 112, Errors: 1, Risky: 1.

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done
