### PR TITLE
Allow the log table to be in a 2nd database

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ return [
      */
     'enabled' => env('ACTIVITY_LOGGER_ENABLED', true),
 
+
+    /*
+     * The logs table can be positioned in a different database from the main database.
+     */
+    'connection' => env('ACTIVITY_LOGGER_DB_CONNECTION', \Config::get('database.default')),
+
+
     /**
      * When running the clean-command all recording activites older than
      * the number of days specified here will be deleted.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "spatie/laravel-activitylog",
+    "name": "JBtje/laravel-activitylog",
     "description": "A very simple activity logger to monitor the users of your website or application",
     "homepage": "https://github.com/spatie/activitylog",
     "keywords":

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "JBtje/laravel-activitylog",
+    "name": "spatie/laravel-activitylog",
     "description": "A very simple activity logger to monitor the users of your website or application",
     "homepage": "https://github.com/spatie/activitylog",
     "keywords":

--- a/config/laravel-activitylog.php
+++ b/config/laravel-activitylog.php
@@ -8,6 +8,11 @@ return [
     'enabled' => env('ACTIVITY_LOGGER_ENABLED', true),
 
     /*
+     * The logs table can be positioned in a different database from the main database.
+     */
+    'connection' => env('ACTIVITY_LOGGER_DB_CONNECTION', \Config::get('database.default')),
+
+    /*
      * When the clean-command is executed, all recording activities older than
      * the number of days specified here will be deleted.
      */

--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -10,7 +10,8 @@ class CreateActivityLogTable extends Migration
      */
     public function up()
     {
-        Schema::create('activity_log', function (Blueprint $table) {
+        Schema::connection(env('ACTIVITY_LOGGER_DB_CONNECTION', \Config::get('database.default')))
+            ->create('activity_log', function (Blueprint $table) {
             $table->increments('id');
             $table->string('log_name')->nullable();
             $table->string('description');
@@ -30,6 +31,6 @@ class CreateActivityLogTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('activity_log');
+        Schema::connection(env('ACTIVITY_LOGGER_DB_CONNECTION', \Config::get('database.default')))->dropIfExists('activity_log');
     }
 }

--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -10,7 +10,7 @@ class CreateActivityLogTable extends Migration
      */
     public function up()
     {
-        Schema::connection(env('ACTIVITY_LOGGER_DB_CONNECTION', \Config::get('database.default')))
+        Schema::connection(config('laravel-activitylog.connection'))
             ->create('activity_log', function (Blueprint $table) {
             $table->increments('id');
             $table->string('log_name')->nullable();
@@ -31,6 +31,6 @@ class CreateActivityLogTable extends Migration
      */
     public function down()
     {
-        Schema::connection(env('ACTIVITY_LOGGER_DB_CONNECTION', \Config::get('database.default')))->dropIfExists('activity_log');
+        Schema::connection(config('laravel-activitylog.connection'))->dropIfExists('activity_log');
     }
 }

--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -30,6 +30,6 @@ class CreateActivityLogTable extends Migration
      */
     public function down()
     {
-        Schema::drop('activity_log');
+        Schema::dropIfExists('activity_log');
     }
 }

--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -56,6 +56,6 @@ class ActivitylogServiceProvider extends ServiceProvider
     {
         $activityModelClassName = self::determineActivityModel();
 
-        return new $activityModelClassName();
+        return (new $activityModelClassName())->setConnection(config('laravel-activitylog.connection'));
     }
 }


### PR DESCRIPTION
The problem: If the system grows, the log table will hold more data and might compromise the load on the database server. It could be a good idea to move the log table to a different database-server, ensuring the main server will not have a heavy write load.

The solution is quite simple: Create an additional ENV varriable "ACTIVITY_LOGGER_DB_CONNECTION", which if set, tells what connection to use. The user has to setup the connection in App/database.php like normal.

Furthermore, I believe it is best practice to use "dropIfExists" instead of "drop" in the database migration "down" method. If "drop" is used (with migration:refresh), but the table has already been removed by the user, it will make the migration hang. Using dropIfExists however allows the process to continue.

Possible problems with this submission:
- There is no additional test. I would love to make one, but have been working with Laravel for 1 week now, and I'm afraid I have no idea how to make a test case for creating a table, drop it manually, and refreshing the migration.
- The ENV variable: I have not yet figured out if the plugin/module/vendor is able to add this to the .env file, or that the user should do this manually. In case it is done automatically, it still needs to be added somewhere. In case it is dome manually: should it not be added to the readme.md?
- I'm sorry for the many pushes, I'm quite new to git as well.... (this will be my first pull request)

If not accepted: please help me (by pointing me in the right direction) how I can improve the pull request.