### PR TITLE
[laravel-55] Fix for $changes in custom Activity model

### DIFF
--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -43,7 +43,7 @@ class Activity extends Model
         return array_get($this->properties->toArray(), $propertyName);
     }
 
-    public function getChangesAttribute(): Collection
+    public function changes(): Collection
     {
         return collect(array_filter($this->properties->toArray(), function ($key) {
             return in_array($key, ['attributes', 'old']);

--- a/tests/CustomActivityModelTest.php
+++ b/tests/CustomActivityModelTest.php
@@ -53,4 +53,23 @@ class CustomActivityModelTest extends TestCase
 
         activity()->log($this->activityDescription);
     }
+
+
+    /** @test */
+    function it_doesnt_conlict_with_laravel_change_tracking()
+    {
+        $this->app['config']->set('activitylog.activity_model', CustomActivityModel::class);
+
+        $properties = [
+            'attributes' => [
+                'name' => 'my name',
+                'text' => null,
+            ],
+        ];
+
+        $activity = activity()->withProperties($properties)->log($this->activityDescription);
+
+        $this->assertEquals($properties, $activity->changes->toArray());
+        $this->assertEquals($properties, $activity->custom_property->toArray());
+    }
 }

--- a/tests/CustomActivityModelTest.php
+++ b/tests/CustomActivityModelTest.php
@@ -69,7 +69,7 @@ class CustomActivityModelTest extends TestCase
 
         $activity = activity()->withProperties($properties)->log($this->activityDescription);
 
-        $this->assertEquals($properties, $activity->changes->toArray());
+        $this->assertEquals($properties, $activity->changes()->toArray());
         $this->assertEquals($properties, $activity->custom_property->toArray());
     }
 }

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -37,7 +37,7 @@ class DetectsChangesTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes->toArray());
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
     /** @test */
@@ -76,7 +76,7 @@ class DetectsChangesTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes->toArray());
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
     /** @test */
@@ -100,7 +100,7 @@ class DetectsChangesTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes->toArray());
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
     /** @test */
@@ -121,7 +121,7 @@ class DetectsChangesTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes->toArray());
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
     /** @test */
@@ -148,7 +148,7 @@ class DetectsChangesTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes->toArray());
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
     /** @test */
@@ -189,7 +189,7 @@ class DetectsChangesTest extends TestCase
                 ],
         ];
 
-        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes->toArray());
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
     /** @test */
@@ -228,7 +228,7 @@ class DetectsChangesTest extends TestCase
                 ],
         ];
 
-        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes->toArray());
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
     /** @test */
@@ -246,7 +246,7 @@ class DetectsChangesTest extends TestCase
 
         $article->save();
 
-        $this->assertEquals(collect(), $this->getLastActivity()->changes);
+        $this->assertEquals(collect(), $this->getLastActivity()->changes());
     }
 
     /** @test */
@@ -263,7 +263,7 @@ class DetectsChangesTest extends TestCase
         ]);
 
         $this->assertEquals('deleted', $this->getLastActivity()->description);
-        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes);
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes());
     }
 
     /** @test */
@@ -296,7 +296,7 @@ class DetectsChangesTest extends TestCase
                 ],
             ],
         ];
-        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes->toArray());
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
     protected function createArticle(): Article

--- a/tests/Models/CustomActivityModel.php
+++ b/tests/Models/CustomActivityModel.php
@@ -6,4 +6,7 @@ use Spatie\Activitylog\Models\Activity;
 
 class CustomActivityModel extends Activity
 {
+    function getCustomPropertyAttribute() {
+        return $this->changes;
+    }
 }

--- a/tests/Models/CustomActivityModel.php
+++ b/tests/Models/CustomActivityModel.php
@@ -7,6 +7,6 @@ use Spatie\Activitylog\Models\Activity;
 class CustomActivityModel extends Activity
 {
     function getCustomPropertyAttribute() {
-        return $this->changes;
+        return $this->changes();
     }
 }


### PR DESCRIPTION
Fixes #233 , #238 

Rename mutator `getChangesAttributes()` to `changes()`
Update use of mutated variable `$changes` to `changes()`
