### PR TITLE
Define fillable attributes and use them for storing changes

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -25,15 +25,17 @@ trait DetectsChanges
 
     public function attributesToBeLogged(): array
     {
+        $attributes = [];
+
         if (isset(static::$logFillable)) {
-            return $this->fillable;
+            $attributes = array_merge($attributes, $this->fillable);
         }
 
-        if (! isset(static::$logAttributes)) {
-            return [];
+        if (isset(static::$logAttributes)) {
+            $attributes = array_merge($attributes, static::$logAttributes);
         }
 
-        return static::$logAttributes;
+        return $attributes;
     }
 
     public function shouldlogOnlyDirty(): bool

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -25,6 +25,10 @@ trait DetectsChanges
 
     public function attributesToBeLogged(): array
     {
+        if (isset(static::$logFillable)) {
+            return $this->fillable;
+        }
+
         if (! isset(static::$logAttributes)) {
             return [];
         }

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -299,6 +299,30 @@ class DetectsChangesTest extends TestCase
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
+    /** @test */
+    public function it_can_use_fillable_as_loggable_attributes()
+    {
+        $articleClass = new class() extends Article {
+            protected $fillable = ['name', 'text'];
+            protected static $logFillable = true;
+
+            use LogsActivity;
+        };
+
+        $article = new $articleClass();
+        $article->name = 'my name';
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'name' => 'my name',
+                'text' => null,
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
     protected function createArticle(): Article
     {
         $article = new $this->article();

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -323,6 +323,32 @@ class DetectsChangesTest extends TestCase
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
+    /** @test */
+    public function it_can_use_both_fillable_and_log_attributes()
+    {
+        $articleClass = new class() extends Article {
+            protected $fillable = ['name'];
+            protected static $logAttributes = ['text'];
+            protected static $logFillable = true;
+
+            use LogsActivity;
+        };
+
+        $article = new $articleClass();
+        $article->name = 'my name';
+        $article->text = 'my text';
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'name' => 'my name',
+                'text' => 'my text',
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
     protected function createArticle(): Article
     {
         $article = new $this->article();


### PR DESCRIPTION
Usually same fields I allow users to fill through forms is what I want to track changes of, so instead of defining same things twice - fillable and logAttributes you can use same definition by saying `$logFillable = true`