### PR TITLE
Log attributes wildcard

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -32,7 +32,13 @@ trait DetectsChanges
         }
 
         if (isset(static::$logAttributes)) {
-            $attributes = array_merge($attributes, static::$logAttributes);
+            if (in_array('*', static::$logAttributes)) {
+                $withoutWildcard = array_diff(static::$logAttributes, ['*']);
+
+                $attributes = array_merge($attributes, array_keys($this->attributes), $withoutWildcard);
+            } else {
+                $attributes = array_merge($attributes, static::$logAttributes);
+            }
         }
 
         return $attributes;


### PR DESCRIPTION
In CRUD heavy application I just want to log any change on model without thinking too much.

This pr enables wildcard `'*'` when defining loggable attributes. What it does it is passing all keys that are defined on `$model->attributes` array. And it keeps any additional defined loggable attributes which is useful in case of relation attributes - for example `['*', 'user.name']`.

