### PR TITLE
Allow detection of changes during forceDelete on model using SoftDeletes

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -53,7 +53,8 @@ trait DetectsChanges
             return [];
         }
 
-        $properties['attributes'] = static::logChanges($this->exists ? $this->fresh() : $this);
+        $tmp = $this;
+        $properties['attributes'] = static::logChanges($this->exists ? $tmp->fresh() ?? $this : $this);
 
         if (static::eventsToBeRecorded()->contains('updated') && $processingEvent == 'updated') {
             $nullProperties = array_fill_keys(array_keys($properties['attributes']), null);

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -121,6 +121,13 @@ class LogsActivityTest extends TestCase
         $this->assertEquals(get_class($this->article), $this->getLastActivity()->subject_type);
         $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
         $this->assertEquals('deleted', $this->getLastActivity()->description);
+
+        $article->forceDelete();
+
+        $this->assertCount(3, Activity::all());
+
+        $this->assertEquals('deleted', $this->getLastActivity()->description);
+        $this->assertNull($article->fresh());
     }
 
     /** @test */


### PR DESCRIPTION
I am not found of my approach as it seems hacky creating a temporary model before calling fresh(), but it is the least obtrusive method I could think of and pass all the tests. I am certain there is a better method, but this does seem to work and pass the tests.