### PR TITLE
fix the attributesToBeLogged() method

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -27,11 +27,11 @@ trait DetectsChanges
     {
         $attributes = [];
 
-        if (isset(static::$logFillable)) {
+        if (isset(static::$logFillable) && static::$logFillable) {
             $attributes = array_merge($attributes, $this->fillable);
         }
 
-        if (isset(static::$logAttributes)) {
+        if (isset(static::$logAttributes) && is_array(static::$logAttributes)) {
             if (in_array('*', static::$logAttributes)) {
                 $withoutWildcard = array_diff(static::$logAttributes, ['*']);
 

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -380,6 +380,51 @@ class DetectsChangesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_use_nothing_as_loggable_attributes()
+    {
+        $articleClass = new class() extends Article {
+            protected $fillable = ['name', 'text'];
+            protected static $logFillable = false;
+
+            use LogsActivity;
+        };
+
+        $article = new $articleClass();
+        $article->name = 'my name';
+        $article->text = 'my text';
+        $article->save();
+
+        $expectedChanges = [];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
+    /** @test */
+    public function it_can_use_text_as_loggable_attributes()
+    {
+        $articleClass = new class() extends Article {
+            protected $fillable = ['name', 'text'];
+            protected static $logAttributes = ['text'];
+            protected static $logFillable = false;
+
+            use LogsActivity;
+        };
+
+        $article = new $articleClass();
+        $article->name = 'my name';
+        $article->text = 'my text';
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'text' => 'my text',
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
+    /** @test */
     public function it_can_use_fillable_as_loggable_attributes()
     {
         $articleClass = new class() extends Article {


### PR DESCRIPTION
Before I start to implement #217 I struggled with the `attributesToBeLogged()` method cause the checks aren't precise enough. In my app I set the `$logFillable = true` in my `BaseModel` but I have 2 models that shouldn't log the attributes. So I want to set it to `false`. The array check is just for type-security.

* `$logFillable` could be `false`
* `$logAttributes` force to be `array`