### PR TITLE
#217 - make hidden attributes obfuscatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `spatie/laravel-activitylog` will be documented in this file
 
+## 2.3.1 - 2017-11-13
+- allow nullable relation when using `logChanges`
+
 ## 2.3.0 - 2017-11-07
 - add a `log` argument to `activitylog:clean`
 

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -36,4 +36,9 @@ return [
      * it should be or extend the Spatie\Activitylog\Models\Activity model.
      */
     'activity_model' => \Spatie\Activitylog\Models\Activity::class,
+
+    /*
+     * This string will be used to obfuscate hidden attributes.
+     */
+    'hidden_obfuscation' => '**hidden**',
 ];

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -93,7 +93,7 @@ trait DetectsChanges
         $changes = [];
         foreach ($model->attributesToBeLogged() as $attribute) {
             $changes += collect([$attribute => self::getModelAttributeValue($model, $attribute)])
-                ->map(function($value) {
+                ->map(function ($value) {
                     return $value instanceof Carbon ? $value->__toString() : $value;
                 })
                 ->toArray();
@@ -106,17 +106,15 @@ trait DetectsChanges
     {
         if (str_contains($attribute, '.')) {
             return self::getRelatedModelAttributeValue($model, $attribute);
-        } elseif(in_array($attribute, $model->getHidden()) && isset($model::$logHidden) && $model::$logHidden) {
+        } elseif (in_array($attribute, $model->getHidden()) && isset($model::$logHidden) && $model::$logHidden) {
             if(isset($model::$logHiddenObfuscated) && $model::$logHiddenObfuscated) {
                 return config('activitylog.hidden_obfuscation');
             }
 
             return $model->getAttribute($attribute);
-        } elseif(!in_array($attribute, $model->getHidden()) && array_key_exists($attribute, $model->getAttributes())) {
+        } elseif (!in_array($attribute, $model->getHidden()) && array_key_exists($attribute, $model->getAttributes())) {
             return $model->getAttribute($attribute);
         }
-
-        return null;
     }
 
     protected static function getRelatedModelAttributeValue(Model $model, string $attribute)
@@ -131,12 +129,10 @@ trait DetectsChanges
 
         $model->loadMissing($relationName);
 
-        if($model->relationLoaded($relationName) && $model->$relationName instanceof Model) {
+        if ($model->relationLoaded($relationName) && $model->$relationName instanceof Model) {
             $relatedModel = $model->$relationName;
 
             return self::getModelAttributeValue($relatedModel, $relatedAttribute);
         }
-
-        return null;
     }
 }

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -111,6 +111,6 @@ trait DetectsChanges
 
         $relatedModel = $model->$relatedModelName ?? $model->$relatedModelName();
 
-        return ["{$relatedModelName}.{$relatedAttribute}" => $relatedModel->$relatedAttribute];
+        return ["{$relatedModelName}.{$relatedAttribute}" => $relatedModel->$relatedAttribute ?? null];
     }
 }

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Activitylog\Traits;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Exceptions\CouldNotLogChanges;
 
@@ -91,26 +92,51 @@ trait DetectsChanges
     {
         $changes = [];
         foreach ($model->attributesToBeLogged() as $attribute) {
-            if (str_contains($attribute, '.')) {
-                $changes += self::getRelatedModelAttributeValue($model, $attribute);
-            } else {
-                $changes += collect($model)->only($attribute)->toArray();
-            }
+            $changes += collect([$attribute => self::getModelAttributeValue($model, $attribute)])
+                ->map(function($value) {
+                    return $value instanceof Carbon ? $value->__toString() : $value;
+                })
+                ->toArray();
         }
 
         return $changes;
     }
 
-    protected static function getRelatedModelAttributeValue(Model $model, string $attribute): array
+    protected static function getModelAttributeValue(Model $model, string $attribute)
+    {
+        if (str_contains($attribute, '.')) {
+            return self::getRelatedModelAttributeValue($model, $attribute);
+        } elseif(in_array($attribute, $model->getHidden()) && isset($model::$logHidden) && $model::$logHidden) {
+            if(isset($model::$logHiddenObfuscated) && $model::$logHiddenObfuscated) {
+                return config('activitylog.hidden_obfuscation');
+            }
+
+            return $model->getAttribute($attribute);
+        } elseif(!in_array($attribute, $model->getHidden()) && array_key_exists($attribute, $model->getAttributes())) {
+            return $model->getAttribute($attribute);
+        }
+
+        return null;
+    }
+
+    protected static function getRelatedModelAttributeValue(Model $model, string $attribute)
     {
         if (substr_count($attribute, '.') > 1) {
             throw CouldNotLogChanges::invalidAttribute($attribute);
         }
 
-        list($relatedModelName, $relatedAttribute) = explode('.', $attribute);
+        $keyParts = explode('.', $attribute);
+        $relationName = array_shift($keyParts);
+        $relatedAttribute = implode('.', $keyParts);
 
-        $relatedModel = $model->$relatedModelName ?? $model->$relatedModelName();
+        $model->loadMissing($relationName);
 
-        return ["{$relatedModelName}.{$relatedAttribute}" => $relatedModel->$relatedAttribute ?? null];
+        if($model->relationLoaded($relationName) && $model->$relationName instanceof Model) {
+            $relatedModel = $model->$relationName;
+
+            return self::getModelAttributeValue($relatedModel, $relatedAttribute);
+        }
+
+        return null;
     }
 }

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -107,12 +107,12 @@ trait DetectsChanges
         if (str_contains($attribute, '.')) {
             return self::getRelatedModelAttributeValue($model, $attribute);
         } elseif (in_array($attribute, $model->getHidden()) && isset($model::$logHidden) && $model::$logHidden) {
-            if(isset($model::$logHiddenObfuscated) && $model::$logHiddenObfuscated) {
+            if (isset($model::$logHiddenObfuscated) && $model::$logHiddenObfuscated) {
                 return config('activitylog.hidden_obfuscation');
             }
 
             return $model->getAttribute($attribute);
-        } elseif (!in_array($attribute, $model->getHidden()) && array_key_exists($attribute, $model->getAttributes())) {
+        } elseif (! in_array($attribute, $model->getHidden()) && array_key_exists($attribute, $model->getAttributes())) {
             return $model->getAttribute($attribute);
         }
     }

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -82,6 +82,44 @@ class DetectsChangesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_store_empty_relation_when_creating_a_model()
+    {
+        $articleClass = new class() extends Article {
+            public static $logAttributes = ['name', 'text', 'user.name'];
+
+            use LogsActivity;
+        };
+
+        $user = User::create([
+            'name' => 'user name',
+        ]);
+
+        $article = $articleClass::create([
+            'name' => 'original name',
+            'text' => 'original text',
+        ]);
+
+        $article->name = 'updated name';
+        $article->text = 'updated text';
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'name' => 'updated name',
+                'text' => 'updated text',
+                'user.name' => null,
+            ],
+            'old' => [
+                'name' => 'original name',
+                'text' => 'original text',
+                'user.name' => null,
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
+    /** @test */
     public function it_can_store_the_changes_when_updating_a_model()
     {
         $article = $this->createArticle();


### PR DESCRIPTION
This is my solution for #217 - all unittests have passed except of:
* `it_will_store_the_values_when_deleting_the_model`
* `it_will_store_the_values_when_deleting_the_model_with_softdelete`

There I had to add the `text` attribute with `null` value for the equal check.