### PR TITLE
Get class name of subject without namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.idea

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -101,5 +101,4 @@ class Activity extends Model
     {
         return (new \ReflectionClass($this->subject))->getShortName();
     }
-
 }

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -94,7 +94,7 @@ class Activity extends Model
     }
 
     /**
-     * Get the Subject Class Name without Namespace
+     * Get the Subject Class Name without Namespace.
      * @return string
      */
     public function getSubjectNameAttribute()

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -92,4 +92,14 @@ class Activity extends Model
             ->where('subject_type', $subject->getMorphClass())
             ->where('subject_id', $subject->getKey());
     }
+
+    /**
+     * Get the Subject Class Name without Namespace
+     * @return string
+     */
+    public function getSubjectNameAttribute()
+    {
+        return (new \ReflectionClass($this->subject))->getShortName();
+    }
+
 }


### PR DESCRIPTION
This is a very simple one just to get the class name of subject without its namespace
```
$lastActivity = Activity::all()->last();
$lastActivity->subject_name; //Returns the Name of the Eloquent model without Namespace
```