### PR TITLE
Add new trait to handle models that are both Causer and Subject

### DIFF
--- a/src/Traits/HasActivity.php
+++ b/src/Traits/HasActivity.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Activitylog\Traits;
+
+use Spatie\Activitylog\ActivitylogServiceProvider;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+trait HasActivity
+{
+    use LogsActivity;
+
+    public function actions(): MorphMany
+    {
+        return $this->morphMany(ActivitylogServiceProvider::determineActivityModel(), 'causer');
+    }
+}

--- a/src/Traits/HasActivity.php
+++ b/src/Traits/HasActivity.php
@@ -4,7 +4,6 @@ namespace Spatie\Activitylog\Traits;
 
 use Spatie\Activitylog\ActivitylogServiceProvider;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Spatie\Activitylog\Traits\LogsActivity;
 
 trait HasActivity
 {

--- a/tests/HasActivityTest.php
+++ b/tests/HasActivityTest.php
@@ -26,19 +26,27 @@ class HasActivityTest extends TestCase
     /** @test */
     public function it_can_log_activity_on_subject_by_same_causer()
     {
-        $user = $this->createUser();
+        $user = $this->loginWithFakeUser();
+
+        $user->name = 'HasActivity Name';
+        $user->save();
+
         $this->assertCount(1, Activity::all());
 
         $this->assertInstanceOf(get_class($this->user), $this->getLastActivity()->subject);
         $this->assertEquals($user->id, $this->getLastActivity()->subject->id);
+        $this->assertEquals($user->id, $this->getLastActivity()->causer->id);
         $this->assertCount(1, $user->activity);
+        $this->assertCount(1, $user->actions);
     }
 
-    protected function createUser(): User
+    public function loginWithFakeUser()
     {
         $user = new $this->user();
-        $user->name = 'my name';
-        $user->save();
+
+        $user::find(1);
+
+        $this->be($user);
 
         return $user;
     }

--- a/tests/HasActivityTest.php
+++ b/tests/HasActivityTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\Activitylog\Test;
+
+use Spatie\Activitylog\Test\Models\User;
+use Spatie\Activitylog\Traits\HasActivity;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\Activitylog\Models\Activity;
+
+class HasActivityTest extends TestCase
+{
+    protected $user;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->user = new class() extends User {
+            use HasActivity;
+            use SoftDeletes;
+        };
+
+        $this->assertCount(0, Activity::all());
+    }
+
+    /** @test */
+    public function it_can_log_activity_on_subject_by_same_causer()
+    {
+        $user = $this->createUser();
+        $this->assertCount(1, Activity::all());
+
+        $this->assertInstanceOf(get_class($this->user), $this->getLastActivity()->subject);
+        $this->assertEquals($user->id, $this->getLastActivity()->subject->id);
+        $this->assertCount(1, $user->activity);
+    }
+
+    protected function createUser(): User
+    {
+        $user = new $this->user();
+        $user->name = 'my name';
+        $user->save();
+
+        return $user;
+    }
+}

--- a/tests/HasActivityTest.php
+++ b/tests/HasActivityTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Activitylog\Test;
 
+use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\User;
 use Spatie\Activitylog\Traits\HasActivity;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Spatie\Activitylog\Models\Activity;
 
 class HasActivityTest extends TestCase
 {

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -14,6 +14,8 @@ class User extends Model implements Authenticatable
 
     protected $guarded = [];
 
+    protected $fillable = ['id', 'name'];
+
     /**
      * Get the name of the unique identifier for the user.
      *


### PR DESCRIPTION
Adds a new trait called HasActivity to handle cases where both CausesActivity and LogsActivity would be used.

Adds an actions() method in place of the activity() method from CausesActivity.

See issues #215, #224, #270, #290, #329.