### PR TITLE
Use child class instead of base class

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -88,7 +88,7 @@ trait LogsActivity
             'deleted',
         ]);
 
-        if (collect(class_uses_recursive(__CLASS__))->contains(SoftDeletes::class)) {
+        if (collect(class_uses_recursive(static::class))->contains(SoftDeletes::class)) {
             $events->push('restored');
         }
 


### PR DESCRIPTION
I had some problems with this method and inheritance.
`__CLASS__` returned my base class which doesn't use soft deletes, but a child class inheriting the base class did. The statement would be false while I expected it to be true.
Fixed it by changing it with `static::class`, this will return the child class.