### PR TITLE
Allow to customize the table name

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -32,6 +32,12 @@ return [
     'subject_returns_soft_deleted_models' => false,
 
     /*
+     * This is the name of the table that will be created to store
+     * the logs. Feel free to update it according to your needs.
+     */
+    'table_name' => 'activity_log',
+
+    /*
      * This model will be used to log activity. The only requirement is that
      * it should be or extend the Spatie\Activitylog\Models\Activity model.
      */

--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -10,7 +10,7 @@ class CreateActivityLogTable extends Migration
      */
     public function up()
     {
-        Schema::create('activity_log', function (Blueprint $table) {
+        Schema::create(config('activitylog.table_name'), function (Blueprint $table) {
             $table->increments('id');
             $table->string('log_name')->nullable();
             $table->text('description');
@@ -30,6 +30,6 @@ class CreateActivityLogTable extends Migration
      */
     public function down()
     {
-        Schema::drop('activity_log');
+        Schema::drop(config('activitylog.table_name'));
     }
 }

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -9,13 +9,20 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class Activity extends Model
 {
-    protected $table = 'activity_log';
+    protected $table;
 
     public $guarded = [];
 
     protected $casts = [
         'properties' => 'collection',
     ];
+
+    public function __construct(array $attributes = [])
+    {
+        $this->table = config('activitylog.table_name');
+
+        parent::__construct($attributes);
+    }
 
     public function subject(): MorphTo
     {


### PR DESCRIPTION
When working on Laravel projects, I usually prefix the names of tables created by third-party packages in order to clearly differentiate them from my own tables. For example, the `activity_log` table would be renamed to `vendor_activity_log`.
This is useful, among other things, to prevent colleagues or even your future self to accidentally alter tables that you’re not supposed to touch.

Right now, in order to get this behaviour with this package, you would need to:
1. publish the default migration
2. modify the migration before running it
3. create a new model extending `\Spatie\Activitylog\Models\Activity` just for updating its `$table` property, which is hardcoded.

If you ran the migration too soon and want to use a new table name after the fact, replace steps **1** and **2** by creating a new migration whose sole purpose is to rename your table.

All of this is doable, but it can quickly become cumbersome, especially if you have to repeat that on multiple projects.

Using [`spatie/laravel-permission`](https://github.com/spatie/laravel-permission) as inspiration, this pull request proposes to add a single config option to allow to customize the table name. It obviously defaults to `activity_log`. It then slightly updates the default migration and the `Activity` model to use the value from the config instead of a hardcoded one.

All tests are still passing.