### PR TITLE
Handle null value for `causedBy`

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -71,6 +71,9 @@ class ActivityLogger
      */
     public function causedBy($modelOrId)
     {
+        if (! $modelOrId)
+            return;
+        
         $model = $this->normalizeCauser($modelOrId);
 
         $this->causedBy = $model;

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -71,8 +71,9 @@ class ActivityLogger
      */
     public function causedBy($modelOrId)
     {
-        if (! $modelOrId)
+        if (! $modelOrId) {
             return;
+        }
         
         $model = $this->normalizeCauser($modelOrId);
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -74,7 +74,7 @@ class ActivityLogger
         if (! $modelOrId) {
             return;
         }
-        
+
         $model = $this->normalizeCauser($modelOrId);
 
         $this->causedBy = $model;

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -18,7 +18,7 @@ class ActivityLogger
 
     protected $logName = '';
 
-    /** @var bool */
+    /** @var bool */$! $
     protected $logEnabled;
 
     /** @var \Illuminate\Database\Eloquent\Model */
@@ -71,7 +71,7 @@ class ActivityLogger
      */
     public function causedBy($modelOrId)
     {
-        if (! $modelOrId) {
+        if ($modelOrId === null) {
             return;
         }
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -18,7 +18,7 @@ class ActivityLogger
 
     protected $logName = '';
 
-    /** @var bool */$! $
+    /** @var bool */
     protected $logEnabled;
 
     /** @var \Illuminate\Database\Eloquent\Model */


### PR DESCRIPTION
This is useful when you have conditional statements for the value.

For example:

```
->causedBy(Auth::check() ? Auth::user() : null)
```