### PR TITLE
refactor and adding an Activity interface to allow use of packages like  jenssegers/laravel-mongodb

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -32,7 +32,8 @@ return [
 
     /*
      * This model will be used to log activity. The only requirement is that
-     * it should be or extend the Spatie\Activitylog\Models\Activity model.
+     * it should be this one or implements the Spatie\Activitylog\Contracts\Activity interface
+     * and extends Illuminate\Database\Eloquent\Model.
      */
     'activity_model' => \Spatie\Activitylog\Models\Activity::class,
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -4,8 +4,8 @@ namespace Spatie\Activitylog;
 
 use Illuminate\Auth\AuthManager;
 use Illuminate\Database\Eloquent\Model;
-use Spatie\Activitylog\Contracts\Activity;
 use Illuminate\Support\Traits\Macroable;
+use Spatie\Activitylog\Contracts\Activity;
 use Illuminate\Contracts\Config\Repository;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
 
@@ -127,7 +127,7 @@ class ActivityLogger
      */
     public function log(string $description)
     {
-        if (! $this->logEnabled) {
+        if (!$this->logEnabled) {
             return;
         }
 
@@ -183,9 +183,9 @@ class ActivityLogger
         return preg_replace_callback('/:[a-z0-9._-]+/i', function ($match) use ($activity) {
             $match = $match[0];
 
-            $attribute = (string) string($match)->between(':', '.');
+            $attribute = (string)string($match)->between(':', '.');
 
-            if (! in_array($attribute, ['subject', 'causer', 'properties'])) {
+            if (!in_array($attribute, ['subject', 'causer', 'properties'])) {
                 return $match;
             }
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -127,7 +127,7 @@ class ActivityLogger
      */
     public function log(string $description)
     {
-        if (!$this->logEnabled) {
+        if (! $this->logEnabled) {
             return;
         }
 
@@ -183,9 +183,9 @@ class ActivityLogger
         return preg_replace_callback('/:[a-z0-9._-]+/i', function ($match) use ($activity) {
             $match = $match[0];
 
-            $attribute = (string)string($match)->between(':', '.');
+            $attribute = (string) string($match)->between(':', '.');
 
-            if (!in_array($attribute, ['subject', 'causer', 'properties'])) {
+            if (! in_array($attribute, ['subject', 'causer', 'properties'])) {
                 return $match;
             }
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -4,7 +4,7 @@ namespace Spatie\Activitylog;
 
 use Illuminate\Auth\AuthManager;
 use Illuminate\Database\Eloquent\Model;
-use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Contracts\Activity;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Config\Repository;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;

--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -16,16 +16,16 @@ class ActivitylogServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__ . '/../config/activitylog.php' => config_path('activitylog.php'),
+            __DIR__.'/../config/activitylog.php' => config_path('activitylog.php'),
         ], 'config');
 
-        $this->mergeConfigFrom(__DIR__ . '/../config/activitylog.php', 'activitylog');
+        $this->mergeConfigFrom(__DIR__.'/../config/activitylog.php', 'activitylog');
 
-        if (!class_exists('CreateActivityLogTable')) {
+        if (! class_exists('CreateActivityLogTable')) {
             $timestamp = date('Y_m_d_His', time());
 
             $this->publishes([
-                __DIR__ . '/../migrations/create_activity_log_table.php.stub' => database_path("/migrations/{$timestamp}_create_activity_log_table.php"),
+                __DIR__.'/../migrations/create_activity_log_table.php.stub' => database_path("/migrations/{$timestamp}_create_activity_log_table.php"),
             ], 'migrations');
         }
     }
@@ -46,8 +46,8 @@ class ActivitylogServiceProvider extends ServiceProvider
     {
         $activityModel = config('activitylog.activity_model') ?? ActivityModel::class;
 
-        if (!is_a($activityModel, Activity::class, true)
-            || !is_a($activityModel, Model::class, true)) {
+        if (! is_a($activityModel, Activity::class, true)
+            || ! is_a($activityModel, Model::class, true)) {
             throw InvalidConfiguration::modelIsNotValid($activityModel);
         }
 

--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -4,7 +4,8 @@ namespace Spatie\Activitylog;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
-use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Contracts\Activity;
+use Spatie\Activitylog\Models\Activity as ActivityModel;
 use Spatie\Activitylog\Exceptions\InvalidConfiguration;
 
 class ActivitylogServiceProvider extends ServiceProvider
@@ -43,9 +44,10 @@ class ActivitylogServiceProvider extends ServiceProvider
 
     public static function determineActivityModel(): string
     {
-        $activityModel = config('activitylog.activity_model') ?? Activity::class;
+        $activityModel = config('activitylog.activity_model') ?? ActivityModel::class;
 
-        if (! is_a($activityModel, Activity::class, true)) {
+        if (! is_a($activityModel, Activity::class, true)
+        || ! is_a($activityModel, Model::class, true)) {
             throw InvalidConfiguration::modelIsNotValid($activityModel);
         }
 

--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -5,8 +5,8 @@ namespace Spatie\Activitylog;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Activitylog\Contracts\Activity;
-use Spatie\Activitylog\Models\Activity as ActivityModel;
 use Spatie\Activitylog\Exceptions\InvalidConfiguration;
+use Spatie\Activitylog\Models\Activity as ActivityModel;
 
 class ActivitylogServiceProvider extends ServiceProvider
 {
@@ -16,16 +16,16 @@ class ActivitylogServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/../config/activitylog.php' => config_path('activitylog.php'),
+            __DIR__ . '/../config/activitylog.php' => config_path('activitylog.php'),
         ], 'config');
 
-        $this->mergeConfigFrom(__DIR__.'/../config/activitylog.php', 'activitylog');
+        $this->mergeConfigFrom(__DIR__ . '/../config/activitylog.php', 'activitylog');
 
-        if (! class_exists('CreateActivityLogTable')) {
+        if (!class_exists('CreateActivityLogTable')) {
             $timestamp = date('Y_m_d_His', time());
 
             $this->publishes([
-                __DIR__.'/../migrations/create_activity_log_table.php.stub' => database_path("/migrations/{$timestamp}_create_activity_log_table.php"),
+                __DIR__ . '/../migrations/create_activity_log_table.php.stub' => database_path("/migrations/{$timestamp}_create_activity_log_table.php"),
             ], 'migrations');
         }
     }
@@ -46,8 +46,8 @@ class ActivitylogServiceProvider extends ServiceProvider
     {
         $activityModel = config('activitylog.activity_model') ?? ActivityModel::class;
 
-        if (! is_a($activityModel, Activity::class, true)
-        || ! is_a($activityModel, Model::class, true)) {
+        if (!is_a($activityModel, Activity::class, true)
+            || !is_a($activityModel, Model::class, true)) {
             throw InvalidConfiguration::modelIsNotValid($activityModel);
         }
 

--- a/src/Contracts/Activity.php
+++ b/src/Contracts/Activity.php
@@ -9,8 +9,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 interface Activity
 {
-
-
     public function subject(): MorphTo;
 
     public function causer(): MorphTo;
@@ -47,5 +45,4 @@ interface Activity
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeForSubject(Builder $query, Model $subject): Builder;
-    
 }

--- a/src/Contracts/Activity.php
+++ b/src/Contracts/Activity.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Spatie\Activitylog\Contracts;
+
+use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+interface Activity
+{
+
+
+    public function subject(): MorphTo;
+
+    public function causer(): MorphTo;
+
+    /**
+     * Get the extra properties with the given name.
+     *
+     * @param string $propertyName
+     *
+     * @return mixed
+     */
+    public function getExtraProperty(string $propertyName);
+
+    public function changes(): Collection;
+
+    public function scopeInLog(Builder $query, ...$logNames): Builder;
+
+    /**
+     * Scope a query to only include activities by a given causer.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param \Illuminate\Database\Eloquent\Model $causer
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeCausedBy(Builder $query, Model $causer): Builder;
+
+    /**
+     * Scope a query to only include activities for a given subject.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param \Illuminate\Database\Eloquent\Model $subject
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeForSubject(Builder $query, Model $subject): Builder;
+    
+}

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -3,8 +3,8 @@
 namespace Spatie\Activitylog\Exceptions;
 
 use Exception;
-use Spatie\Activitylog\Models\Activity;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Contracts\Activity;
 
 class InvalidConfiguration extends Exception
 {

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -4,11 +4,12 @@ namespace Spatie\Activitylog\Exceptions;
 
 use Exception;
 use Spatie\Activitylog\Models\Activity;
+use Illuminate\Database\Eloquent\Model;
 
 class InvalidConfiguration extends Exception
 {
     public static function modelIsNotValid(string $className)
     {
-        return new static("The given model class `$className` does not extend `".Activity::class.'`');
+        return new static("The given model class `$className` does not implements `".Activity::class.'` and extend `'.Model::class.'`');
     }
 }

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -10,6 +10,6 @@ class InvalidConfiguration extends Exception
 {
     public static function modelIsNotValid(string $className)
     {
-        return new static("The given model class `$className` does not implements `".Activity::class.'` and extend `'.Model::class.'`');
+        return new static("The given model class `$className` does not implement `".Activity::class.'` or it does not extend `'.Model::class.'`');
     }
 }

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -2,11 +2,11 @@
 
 namespace Spatie\Activitylog\Models;
 
-use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 
 class Activity extends Model implements ActivityContract
 {

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -2,12 +2,13 @@
 
 namespace Spatie\Activitylog\Models;
 
+use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class Activity extends Model
+class Activity extends Model implements ActivityContract
 {
     protected $table;
 

--- a/tests/CustomActivityModelTest.php
+++ b/tests/CustomActivityModelTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\Activitylog\Test;
 
 use Spatie\Activitylog\Test\Models\Activity;
-use Spatie\Activitylog\Exceptions\InvalidConfiguration;
 use Spatie\Activitylog\Test\Models\InvalidActivity;
+use Spatie\Activitylog\Exceptions\InvalidConfiguration;
 use Spatie\Activitylog\Test\Models\AnotherInvalidActivity;
 
 class CustomActivityModelTest extends TestCase

--- a/tests/CustomActivityModelTest.php
+++ b/tests/CustomActivityModelTest.php
@@ -3,8 +3,9 @@
 namespace Spatie\Activitylog\Test;
 
 use Spatie\Activitylog\Exceptions\InvalidConfiguration;
-use Spatie\Activitylog\Test\Models\CustomActivityModel;
-use Spatie\Activitylog\Test\Models\InvalidActivityModel;
+use Spatie\Activitylog\Test\Models\Activity;
+use Spatie\Activitylog\Test\Models\AnotherInvalidActivity;
+use Spatie\Activitylog\Test\Models\InvalidActivity;
 
 class CustomActivityModelTest extends TestCase
 {
@@ -25,13 +26,13 @@ class CustomActivityModelTest extends TestCase
     /** @test */
     public function it_can_log_activity_using_a_custom_model()
     {
-        $this->app['config']->set('activitylog.activity_model', CustomActivityModel::class);
+        $this->app['config']->set('activitylog.activity_model', Activity::class);
 
         $activity = activity()->log($this->activityDescription);
 
         $this->assertEquals($this->activityDescription, $activity->description);
 
-        $this->assertInstanceOf(CustomActivityModel::class, $activity);
+        $this->assertInstanceOf(Activity::class, $activity);
     }
 
     /** @test */
@@ -47,7 +48,7 @@ class CustomActivityModelTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_model_doesnt_implements_activity()
     {
-        $this->app['config']->set('activitylog.activity_model', InvalidActivityModel::class);
+        $this->app['config']->set('activitylog.activity_model', InvalidActivity::class);
 
         $this->expectException(InvalidConfiguration::class);
 
@@ -57,7 +58,7 @@ class CustomActivityModelTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_model_doesnt_extend_model()
     {
-        $this->app['config']->set('activitylog.activity_model', InvalidActivityModel::class);
+        $this->app['config']->set('activitylog.activity_model', AnotherInvalidActivity::class);
 
         $this->expectException(InvalidConfiguration::class);
 
@@ -67,7 +68,7 @@ class CustomActivityModelTest extends TestCase
     /** @test */
     public function it_doesnt_conlict_with_laravel_change_tracking()
     {
-        $this->app['config']->set('activitylog.activity_model', CustomActivityModel::class);
+        $this->app['config']->set('activitylog.activity_model', Activity::class);
 
         $properties = [
             'attributes' => [

--- a/tests/CustomActivityModelTest.php
+++ b/tests/CustomActivityModelTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Activitylog\Test;
 
-use Spatie\Activitylog\Exceptions\InvalidConfiguration;
 use Spatie\Activitylog\Test\Models\Activity;
-use Spatie\Activitylog\Test\Models\AnotherInvalidActivity;
+use Spatie\Activitylog\Exceptions\InvalidConfiguration;
 use Spatie\Activitylog\Test\Models\InvalidActivity;
+use Spatie\Activitylog\Test\Models\AnotherInvalidActivity;
 
 class CustomActivityModelTest extends TestCase
 {

--- a/tests/CustomActivityModelTest.php
+++ b/tests/CustomActivityModelTest.php
@@ -45,7 +45,17 @@ class CustomActivityModelTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_an_exception_when_model_doesnt_extend_package_model()
+    public function it_throws_an_exception_when_model_doesnt_implements_activity()
+    {
+        $this->app['config']->set('activitylog.activity_model', InvalidActivityModel::class);
+
+        $this->expectException(InvalidConfiguration::class);
+
+        activity()->log($this->activityDescription);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_model_doesnt_extend_model()
     {
         $this->app['config']->set('activitylog.activity_model', InvalidActivityModel::class);
 

--- a/tests/Models/Activity.php
+++ b/tests/Models/Activity.php
@@ -5,8 +5,8 @@ namespace Spatie\Activitylog\Test\Models;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 
 class Activity extends Model implements ActivityContract
 {

--- a/tests/Models/Activity.php
+++ b/tests/Models/Activity.php
@@ -5,10 +5,10 @@ namespace Spatie\Activitylog\Test\Models;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Spatie\Activitylog\Contracts\Activity;
+use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class CustomInvalidActivityModel implements Activity
+class Activity extends Model implements ActivityContract
 {
     protected $table;
 
@@ -40,7 +40,7 @@ class CustomInvalidActivityModel implements Activity
     }
 
     /**
-     * Get the extra properties with the given name.
+     * Get the extra property with the given name.
      *
      * @param string $propertyName
      *

--- a/tests/Models/AnotherInvalidActivity.php
+++ b/tests/Models/AnotherInvalidActivity.php
@@ -5,10 +5,10 @@ namespace Spatie\Activitylog\Test\Models;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Spatie\Activitylog\Contracts\Activity;
+use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class CustomActivityModel extends Model implements Activity
+class AnotherInvalidActivity implements ActivityContract
 {
     protected $table;
 

--- a/tests/Models/AnotherInvalidActivity.php
+++ b/tests/Models/AnotherInvalidActivity.php
@@ -5,8 +5,8 @@ namespace Spatie\Activitylog\Test\Models;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 
 class AnotherInvalidActivity implements ActivityContract
 {

--- a/tests/Models/CustomActivityModel.php
+++ b/tests/Models/CustomActivityModel.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Activitylog\Test\Models;
 
-use Spatie\Activitylog\Contracts\Activity;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Spatie\Activitylog\Contracts\Activity;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class CustomActivityModel extends Model implements Activity

--- a/tests/Models/CustomInvalidActivityModel.php
+++ b/tests/Models/CustomInvalidActivityModel.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class CustomActivityModel extends Model implements Activity
+class CustomInvalidActivityModel implements Activity
 {
     protected $table;
 

--- a/tests/Models/CustomInvalidActivityModel.php
+++ b/tests/Models/CustomInvalidActivityModel.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Activitylog\Test\Models;
 
-use Spatie\Activitylog\Contracts\Activity;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Spatie\Activitylog\Contracts\Activity;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class CustomInvalidActivityModel implements Activity

--- a/tests/Models/InvalidActivity.php
+++ b/tests/Models/InvalidActivity.php
@@ -4,6 +4,6 @@ namespace Spatie\Activitylog\Test\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class InvalidActivityModel extends Model
+class InvalidActivity extends Model
 {
 }

--- a/tests/Models/InvalidActivityModel.php
+++ b/tests/Models/InvalidActivityModel.php
@@ -1,7 +1,9 @@
 <?php
 
 namespace Spatie\Activitylog\Test\Models;
+
 use Illuminate\Database\Eloquent\Model;
+
 class InvalidActivityModel extends Model
 {
 }

--- a/tests/Models/InvalidActivityModel.php
+++ b/tests/Models/InvalidActivityModel.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Spatie\Activitylog\Test\Models;
-
-class InvalidActivityModel
+use Illuminate\Database\Eloquent\Model;
+class InvalidActivityModel extends Model
 {
 }


### PR DESCRIPTION
I was interested to use this package with mongodb and the jenssegers/laravel-mongodb.
To make it easier to use packages like jenssegers/laravel-mongodb, I have removed the obligation to extend your model Activity. I created an Activity interface and I modified the control in the ServiceProvider so that Activity model should implement the Activity interface and extend Illuminate\Database\Eloquent\Model.
In this way, to use this package with MongoDB it is sufficient to create an activity class like the following one
```

use Spatie\Activitylog\Contracts\Activity as ActivityContract;
use Illuminate\Support\Collection;
use Illuminate\Database\Eloquent\Builder;
use Illuminate\Database\Eloquent\Relations\MorphTo;
use Jenssegers\Mongodb\Eloquent\Model as Moloquent;
class Activity extends Moloquent implements ActivityContract
{
    protected $table = 'activity_log';
    protected $connection = 'mongodb'; //mongodb connection
    protected $collection = 'activity_log';
```
I've also modified some test to verify the implementation of the Interface and the extension of Illuminate\Database\Eloquent\Model.

I hope this could be useful for the ones who wants to use this package with mongodb instead of the other database drivers shipped with Laravel.

Thank you.

Best regards,
Leonardo Padovani
