### PR TITLE
Fixed ActivityLogger contaminated performedOn model.

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -58,6 +58,13 @@ class ActivityLogger
 
         return $this;
     }
+    
+    public function removePerformedOn()
+    {
+        $this->performedOn = null;
+
+        return $this;
+    }
 
     public function on(Model $model)
     {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -7,6 +7,6 @@ if (! function_exists('activity')) {
     {
         $defaultLogName = config('activitylog.default_log_name');
 
-        return app(ActivityLogger::class)->useLog($logName ?? $defaultLogName);
+        return app(ActivityLogger::class)->removePerformedOn()->useLog($logName ?? $defaultLogName);
     }
 }


### PR DESCRIPTION
Sometimes developers need to keep performedOn model null.
And I think the activity helper function should always return a clean ActivityLogger. So that the previous performedOn model will not affect later logs.