### PR TITLE
Delete older than 180 days

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -11,7 +11,7 @@ return [
      * When the clean-command is executed, all recording activities older than
      * the number of days specified here will be deleted.
      */
-    'delete_records_older_than_days' => 365,
+    'delete_records_older_than_days' => 180,
 
     /*
      * If no log name is passed to the activity() helper


### PR DESCRIPTION
EU GDPR demands to delete logs after 180 days when possible, therefor I suggest the default is 180 days.