### PR TITLE
Merge properties on multiple withProperties call

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -103,7 +103,7 @@ class ActivityLogger
      */
     public function withProperties($properties)
     {
-        $this->properties = collect($properties);
+        $this->properties = $this->properties->merge(collect($properties));
 
         return $this;
     }

--- a/tests/ActivityloggerTest.php
+++ b/tests/ActivityloggerTest.php
@@ -151,6 +151,31 @@ class ActivityloggerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_log_activity_and_merge_properties()
+    {
+        $properties = [
+            'property' => [
+                'subProperty' => 'value',
+            ],
+        ];
+
+        $mergedProperties = [
+            'anotherProperty' => 'another_value',
+        ];
+
+        activity()
+            ->withProperties($properties)
+            ->withProperties($mergedProperties)
+            ->log($this->activityDescription);
+
+        $firstActivity = Activity::first();
+
+        $this->assertInstanceOf(Collection::class, $firstActivity->properties);
+        $this->assertEquals('value', $firstActivity->getExtraProperty('property.subProperty'));
+        $this->assertEquals('another_value', $firstActivity->getExtraProperty('anotherProperty'));
+    }
+
+    /** @test */
     public function it_can_translate_a_given_causer_id_to_an_object()
     {
         $userId = User::first()->id;


### PR DESCRIPTION
When using `withProperties` multiple times, the internal `$properties` collection will be overwritten. This PR solves this problem by merging the two collection.

My use case was the following: I made a helper function to set some default property (e.g. `activity_for_admin`). If I used this helper and then called `withProperties`, the default (set by me) properties was overwritten, so I had to use `withProperty` for every prop I wanted to set.