### PR TITLE
Allow empty changes to be ignored from logging

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -104,6 +104,15 @@ trait LogsActivity
         return static::$ignoreChangedAttributes;
     }
 
+    public function shouldlogEmptyChanges(): bool
+    {
+        if (! isset(static::$logEmptyChanges)) {
+            return true;
+        }
+
+        return static::$logEmptyChanges;
+    }
+
     protected function shouldLogEvent(string $eventName): bool
     {
         if (! $this->enableLoggingModelsEvents) {
@@ -118,6 +127,10 @@ trait LogsActivity
             if ($this->getDirty()['deleted_at'] === null) {
                 return false;
             }
+        }
+
+        if (!$this->shouldlogEmptyChanges() && empty($this->attributeValuesToBeLogged($eventName)['attributes'])) {
+            return false;
         }
 
         //do not log update event if only ignored attributes are changed

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -129,7 +129,7 @@ trait LogsActivity
             }
         }
 
-        if (!$this->shouldlogEmptyChanges() && empty($this->attributeValuesToBeLogged($eventName)['attributes'])) {
+        if (! $this->shouldlogEmptyChanges() && empty($this->attributeValuesToBeLogged($eventName)['attributes'])) {
             return false;
         }
 

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -153,7 +153,7 @@ class DetectsChangesTest extends TestCase
         $article->json = '[]';
 
         $article->save();
-        
+
         $this->assertNotEquals('updated', $this->getLastActivity()->description);
     }
 

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -144,6 +144,20 @@ class DetectsChangesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_ignore_empty_changes()
+    {
+        $article = $this->createDirtyArticle();
+
+        $article::$logEmptyChanges = false;
+
+        $article->json = '[]';
+
+        $article->save();
+        
+        $this->assertNotEquals('updated', $this->getLastActivity()->description);
+    }
+
+    /** @test */
     public function it_can_store_dirty_changes_only()
     {
         $article = $this->createDirtyArticle();
@@ -627,6 +641,8 @@ class DetectsChangesTest extends TestCase
             public static $logAttributes = ['name', 'text'];
 
             public static $logOnlyDirty = true;
+
+            public static $logEmptyChanges = true;
 
             use LogsActivity;
         };


### PR DESCRIPTION
The issue being solved here is that making changes to any attribute not stored in `$logAttributes`  (when using `$logOnlyDirty = true`) still triggers the creation of a new log event into the database which contains empty changes:

```
[
    'attributes' => [
    ],
    'old' => [
    ],
]
```

Certain applications may wish to ignore these empty changesets without having to specify all model attributes in `$ignoreChangedAttributes` (which could potentially be error prone). Thus, this change offers users the ability to set the `$logEmptyChanges` attribute to either enable or disable empty changeset logging.



Note: it could be the case that we don't need this new `$logAttributes` option. Instead, this logic could automatically be triggered by the fact that `$logOnlyDirty` is already set. So when `$logOnlyDirty` is true, empty changesets are ignored because the system should "log only dirty" while an empty changeset obviously has no dirty attributes. 
However, there might be applications expecting these empty changesets to be stored. While there are currently no contracts (within the documentation or in the tests) stating that the activitylogger will store these empty changesets, I can't be for certain that certain users aren't expecting this "undefined" behavior. 