### PR TITLE
it's Help us to express the names of the concept of the fields

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -87,7 +87,17 @@ trait DetectsChanges
                 ->only(array_keys($properties['attributes']))
                 ->all();
         }
-
+        foreach (static::$logAttributes as $key => $value) {
+            if(!is_numeric($key)){ // if $logAttributes not have custom keies
+                $properties['attributes'][$key] = $properties['attributes'][$value];
+                unset($properties['attributes'][$value]);
+                // if status is update
+                if(isset($properties['old'])){ // in_array() didn't work :D
+                    $properties['old'][$key] = $properties['old'][$value];
+                    unset($properties['old'][$value]);
+                }
+            }
+        }
         return $properties;
     }
 


### PR DESCRIPTION
it's Help us to express the names of the concept of the fields,
for example, the use of "account number" instead of "acc_num"
by
protected static $logAttributes = ['account number'=>'acc_num'];