### PR TITLE
Allow custom descriptions for events

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -61,7 +61,16 @@ trait LogsActivity
 
     public function getDescriptionForEvent(string $eventName): string
     {
+        if ($customDescriptions = $this->getCustomDescriptionsForEvents($eventName)) {
+            return $customDescriptions[$eventName] ?? $eventName;
+        }
+
         return $eventName;
+    }
+
+    public function getCustomDescriptionsForEvents(string $eventName): array
+    {
+        return [];
     }
 
     public function getLogNameToUse(string $eventName = ''): string


### PR DESCRIPTION
This PR allows for custom description for each event. This is useful if you have custom events and would like to give it a unique description.

**Usage:** 

```
public function getCustomDescriptionsForEvents($eventName)
{
    return [
        'created' => "This model was $eventName",
        'assigned' => "This model has been $eventName"
    ];
}
```