### PR TITLE
Update create_activity_log_table.php.stub

### DIFF
--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
@@ -30,6 +31,6 @@ class CreateActivityLogTable extends Migration
      */
     public function down()
     {
-        Schema::drop(config('activitylog.table_name'));
+        Schema::dropIfExists(config('activitylog.table_name'));
     }
 }


### PR DESCRIPTION
When running `php artisan make:model xxx -mcr` it will create a migration file with the "use Schema" line, as well as "dropIfExists".
These improvements don't fix a problem, but do solve the yellow highlight in phpstorm, as well as fix errors when manual removing the table and running `php artisan migrate:refresh`