### PR TITLE
Avoid Data Too Long SQL error when saving log description

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -4,6 +4,7 @@ namespace Spatie\Activitylog;
 
 use Illuminate\Auth\AuthManager;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Builder;
 use Spatie\Activitylog\Models\Activity;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Config\Repository;
@@ -170,7 +171,9 @@ class ActivityLogger
 
         $activity->properties = $this->properties;
 
-        $activity->description = $this->replacePlaceholders($description, $activity);
+        $fullDescription = $this->replacePlaceholders($description, $activity);
+
+        $activity->description = str_limit($fullDescription, Builder::$defaultStringLength - 3);
 
         $activity->log_name = $this->logName;
 

--- a/tests/ActivityloggerTest.php
+++ b/tests/ActivityloggerTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Activitylog\Test;
 
 use Auth;
+use Illuminate\Database\Schema\Builder;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\User;
@@ -272,5 +273,13 @@ class ActivityloggerTest extends TestCase
         activity()->causedBy(null)->log('nothing');
 
         $this->markTestAsPassed();
+    }
+
+    /** @test */
+    function it_will_cut_description_text_to_fit_in_db_string_field()
+    {
+        activity()->log('The sun was shining on the sea, Shining with all his might: He did his very best to make The billows smooth and bright -- And this was odd, because it was The middle of the night. The moon was shining sulkily, Because she thought the sun Had got no business to be there After the day was done -- "It\'s very rude of him," she said, "To come and spoil the fun!');
+
+        $this->assertEquals(Builder::$defaultStringLength, mb_strlen($this->getLastActivity()->description));
     }
 }


### PR DESCRIPTION
Hi,
This is only a proposal. I've been using this package for some time now and I always used the description field to provide an admin user with some feedback about the activity that happened. Using the template feature is great, but it sometimes creates a very long description that will eventually result in a "Data too long" SQL error. I could change the "string" field type to make it larger but I feel this would be an overhead. So my idea was simply to cut the description text using Laravel's str_limit function to limit it to the Schema Builder's default string length.

Thanks!

Xavier