### PR TITLE
add $logUnguarded property and logic 

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -39,7 +39,7 @@ trait DetectsChanges
             $attributes = array_merge($attributes, array_diff(static::$logAttributes, ['*']));
 
             if (in_array('*', static::$logAttributes)) {
-                $attributes = array_merge($attributes, array_keys($this->attributes));
+                $attributes = array_merge($attributes, array_keys($this->getAttributes()));
             }
         }
 

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -28,7 +28,7 @@ trait DetectsChanges
         $attributes = [];
 
         if (isset(static::$logFillable) && static::$logFillable) {
-            $attributes = array_merge($attributes, $this->fillable);
+            $attributes = array_merge($attributes, $this->getFillable());
         }
 
         if (isset(static::$logAttributes) && is_array(static::$logAttributes)) {

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -32,12 +32,10 @@ trait DetectsChanges
         }
 
         if (isset(static::$logAttributes) && is_array(static::$logAttributes)) {
-            if (in_array('*', static::$logAttributes)) {
-                $withoutWildcard = array_diff(static::$logAttributes, ['*']);
+            $attributes = array_merge($attributes, array_diff(static::$logAttributes, ['*']));
 
-                $attributes = array_merge($attributes, array_keys($this->attributes), $withoutWildcard);
-            } else {
-                $attributes = array_merge($attributes, static::$logAttributes);
+            if (in_array('*', static::$logAttributes)) {
+                $attributes = array_merge($attributes, array_keys($this->attributes));
             }
         }
 

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -31,6 +31,10 @@ trait DetectsChanges
             $attributes = array_merge($attributes, $this->getFillable());
         }
 
+        if (isset(static::$logUnguarded) && static::$logUnguarded) {
+            $attributes = array_merge($attributes, array_diff(array_keys($this->getAttributes()), $this->getGuarded()));
+        }
+
         if (isset(static::$logAttributes) && is_array(static::$logAttributes)) {
             $attributes = array_merge($attributes, array_diff(static::$logAttributes, ['*']));
 

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -612,6 +612,32 @@ class DetectsChangesTest extends TestCase
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
+    /** @test */
+    public function it_can_use_unguarded_as_loggable_attributes()
+    {
+        $articleClass = new class() extends Article {
+            protected $guarded = ['text', 'json'];
+            protected static $logAttributesToIgnore = ['id', 'created_at', 'updated_at', 'deleted_at'];
+            protected static $logUnguarded = true;
+
+            use LogsActivity;
+        };
+
+        $article = new $articleClass();
+        $article->name = 'my name';
+        $article->text = 'my new text';
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'name' => 'my name',
+                'user_id' => null,
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
     protected function createArticle(): Article
     {
         $article = new $this->article();


### PR DESCRIPTION
**solves** #356 & #217 

`$logUnguarded` is a new `boolean` static property which adds a new way to define attributes to be logged. Instead of listing all attributes to log it will add all attributes not listed as `$guarded` to be logged. It works only with attributes that are returned by `$model->getAttributes()`