### PR TITLE
add failing unittests for inaccessible attributes

### DIFF
--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -625,13 +625,52 @@ class DetectsChangesTest extends TestCase
 
         $article = new $articleClass();
         $article->name = 'my name';
-        $article->text = 'my new text';
+        $article->text = 'my text';
         $article->save();
 
         $expectedChanges = [
             'attributes' => [
                 'name' => 'my name',
-                'text' => 'my new text',
+                'text' => 'my text',
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
+    /** @test */
+    public function it_can_use_overloaded_as_loggable_attributes()
+    {
+        $articleClass = new class() extends Article {
+            protected $fillable = ['name', 'text'];
+            protected static $logAttributes = ['name', 'text', 'description'];
+
+            use LogsActivity;
+
+            protected $description;
+
+            public function setDescriptionAttribute($value)
+            {
+                $this->description = $value;
+            }
+
+            public function getDescriptionAttribute()
+            {
+                return $this->description;
+            }
+        };
+
+        $article = new $articleClass();
+        $article->name = 'my name';
+        $article->text = 'my text';
+        $article->description = 'my description';
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'name' => 'my name',
+                'text' => 'my text',
+                'description' => 'my description',
             ],
         ];
 

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -647,16 +647,14 @@ class DetectsChangesTest extends TestCase
 
             use LogsActivity;
 
-            protected $description;
-
             public function setDescriptionAttribute($value)
             {
-                $this->description = $value;
+                $this->attributes['json'] = json_encode(['description' => $value]);
             }
 
             public function getDescriptionAttribute()
             {
-                return $this->description;
+                return array_get(json_decode($this->attributes['json'], true), 'description');
             }
         };
 

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -612,6 +612,32 @@ class DetectsChangesTest extends TestCase
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
+    /** @test */
+    public function it_can_use_hidden_as_loggable_attributes()
+    {
+        $articleClass = new class() extends Article {
+            protected $hidden = ['text'];
+            protected $fillable = ['name', 'text'];
+            protected static $logAttributes = ['name', 'text'];
+
+            use LogsActivity;
+        };
+
+        $article = new $articleClass();
+        $article->name = 'my name';
+        $article->text = 'my new text';
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'name' => 'my name',
+                'text' => 'my new text',
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
     protected function createArticle(): Article
     {
         $article = new $this->article();


### PR DESCRIPTION
In opposit to #217 hidden attributes aren't logged at all. Even if I list them as *loggable*.
This is caused by the use of `collect()->only()` which calls `$model->toArray()` and this removes all hidden attributes.
https://github.com/spatie/laravel-activitylog/blob/c1dd4932d21216a3d0b23778c867ee1000eb87c7/src/Traits/DetectsChanges.php#L101
The usage of `collect()` is also criticized in #285 & #286 for another reason.

Both would be solvable by dropping `collect()` at all and use the model accessors directly.
```php
$changes += [$attribute => $model->$attribute];
```

This works for all kinds of attributes, even overloaded but not appended ones (these are also not accessible at the moment).

**it_can_use_hidden_as_loggable_attributes**
```diff
1) Spatie\Activitylog\Test\DetectsChangesTest::it_can_use_hidden_as_loggable_attributes
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'attributes' => Array (
         'name' => 'my name'
-        'text' => 'my text'
     )
 )
```

**it_can_use_overloaded_as_loggable_attributes**
```diff
1) Spatie\Activitylog\Test\DetectsChangesTest::it_can_use_overloaded_as_loggable_attributes
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     'attributes' => Array (
         'name' => 'my name'
         'text' => 'my text'
-        'description' => 'my description'
     )
 )
```