### PR TITLE
Add tap method to ActivityLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `spatie/laravel-activitylog` will be documented in this file
 
+## 3.2.0 - 2019-01-29
+
+- add `ActivityLogger::tap()` method
+- add `LogsActivity::tapActivity()` method
+- the `ActivityLogger` will work on an activity model instance instead of cache variables
+
 ## 3.1.2 - 2018-10-18
 
 - add `shouldLogUnguarded()` method

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -2,12 +2,13 @@
 
 namespace Spatie\Activitylog;
 
+use Closure;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
-use Spatie\Activitylog\Contracts\Activity;
 use Illuminate\Contracts\Config\Repository;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
+use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 
 class ActivityLogger
 {
@@ -16,16 +17,7 @@ class ActivityLogger
     /** @var \Illuminate\Auth\AuthManager */
     protected $auth;
 
-    protected $logName = '';
-
-    /** @var \Illuminate\Database\Eloquent\Model */
-    protected $performedOn;
-
-    /** @var \Illuminate\Database\Eloquent\Model */
-    protected $causedBy;
-
-    /** @var \Illuminate\Support\Collection */
-    protected $properties;
+    protected $defaultLogName = '';
 
     /** @var string */
     protected $authDriver;
@@ -33,17 +25,16 @@ class ActivityLogger
     /** @var \Spatie\Activitylog\ActivityLogStatus */
     protected $logStatus;
 
+    /** @var \Spatie\Activitylog\Contracts\Activity */
+    protected $activity;
+
     public function __construct(AuthManager $auth, Repository $config, ActivityLogStatus $logStatus)
     {
         $this->auth = $auth;
 
-        $this->properties = collect();
-
         $this->authDriver = $config['activitylog']['default_auth_driver'] ?? $auth->getDefaultDriver();
 
-        $this->causedBy = $auth->guard($this->authDriver)->user();
-
-        $this->logName = $config['activitylog']['default_log_name'];
+        $this->defaultLogName = $config['activitylog']['default_log_name'];
 
         $this->logStatus = $logStatus;
     }
@@ -57,7 +48,7 @@ class ActivityLogger
 
     public function performedOn(Model $model)
     {
-        $this->performedOn = $model;
+        $this->getActivity()->subject()->associate($model);
 
         return $this;
     }
@@ -75,7 +66,7 @@ class ActivityLogger
 
         $model = $this->normalizeCauser($modelOrId);
 
-        $this->causedBy = $model;
+        $this->getActivity()->causer()->associate($model);
 
         return $this;
     }
@@ -87,21 +78,21 @@ class ActivityLogger
 
     public function withProperties($properties)
     {
-        $this->properties = collect($properties);
+        $this->getActivity()->properties = collect($properties);
 
         return $this;
     }
 
     public function withProperty(string $key, $value)
     {
-        $this->properties->put($key, $value);
+        $this->getActivity()->properties = $this->getActivity()->properties->put($key, $value);
 
         return $this;
     }
 
     public function useLog(string $logName)
     {
-        $this->logName = $logName;
+        $this->getActivity()->log_name = $logName;
 
         return $this;
     }
@@ -109,6 +100,13 @@ class ActivityLogger
     public function inLog(string $logName)
     {
         return $this->useLog($logName);
+    }
+
+    public function tap(Closure $callback)
+    {
+        call_user_func($callback, $this->getActivity());
+
+        return $this;
     }
 
     public function enableLogging()
@@ -131,23 +129,13 @@ class ActivityLogger
             return;
         }
 
-        $activity = ActivitylogServiceProvider::getActivityModelInstance();
-
-        if ($this->performedOn) {
-            $activity->subject()->associate($this->performedOn);
-        }
-
-        if ($this->causedBy) {
-            $activity->causer()->associate($this->causedBy);
-        }
-
-        $activity->properties = $this->properties;
+        $activity = $this->activity;
 
         $activity->description = $this->replacePlaceholders($description, $activity);
 
-        $activity->log_name = $this->logName;
-
         $activity->save();
+
+        $this->activity = null;
 
         return $activity;
     }
@@ -167,7 +155,7 @@ class ActivityLogger
         throw CouldNotLogActivity::couldNotDetermineUser($modelOrId);
     }
 
-    protected function replacePlaceholders(string $description, Activity $activity): string
+    protected function replacePlaceholders(string $description, ActivityContract $activity): string
     {
         return preg_replace_callback('/:[a-z0-9._-]+/i', function ($match) use ($activity) {
             $match = $match[0];
@@ -190,5 +178,18 @@ class ActivityLogger
 
             return array_get($attributeValue, $propertyName, $match);
         }, $description);
+    }
+
+    protected function getActivity(): ActivityContract
+    {
+        if(!$this->activity instanceof ActivityContract) {
+            $this->activity = ActivitylogServiceProvider::getActivityModelInstance();
+            $this
+                ->useLog($this->defaultLogName)
+                ->withProperties([])
+                ->causedBy($this->auth->guard($this->authDriver)->user());
+        }
+
+        return $this->activity;
     }
 }

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -158,11 +158,7 @@ class ActivityLogger
             return $modelOrId;
         }
 
-        if (starts_with(app()->version(), '5.1')) {
-            $model = $this->auth->driver($this->authDriver)->getProvider()->retrieveById($modelOrId);
-        } else {
-            $model = $this->auth->guard($this->authDriver)->getProvider()->retrieveById($modelOrId);
-        }
+        $model = $this->auth->guard($this->authDriver)->getProvider()->retrieveById($modelOrId);
 
         if ($model) {
             return $model;

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -182,7 +182,7 @@ class ActivityLogger
 
     protected function getActivity(): ActivityContract
     {
-        if(!$this->activity instanceof ActivityContract) {
+        if (! $this->activity instanceof ActivityContract) {
             $this->activity = ActivitylogServiceProvider::getActivityModelInstance();
             $this
                 ->useLog($this->defaultLogName)

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -49,8 +49,6 @@ class ActivityLogger
 
         $this->logName = $config['activitylog']['default_log_name'];
 
-        $this->logEnabled = $config['activitylog']['enabled'] ?? true;
-
         $this->logStatus = $logStatus;
     }
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Activitylog;
 
-use Closure;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
@@ -102,9 +101,9 @@ class ActivityLogger
         return $this->useLog($logName);
     }
 
-    public function tap(Closure $callback)
+    public function tap(callable $callback, string $eventName = null)
     {
-        call_user_func($callback, $this->getActivity());
+        call_user_func($callback, $this->getActivity(), $eventName);
 
         return $this;
     }

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -41,11 +41,7 @@ class ActivityLogger
 
         $this->authDriver = $config['activitylog']['default_auth_driver'] ?? $auth->getDefaultDriver();
 
-        if (starts_with(app()->version(), '5.1')) {
-            $this->causedBy = $auth->driver($this->authDriver)->user();
-        } else {
-            $this->causedBy = $auth->guard($this->authDriver)->user();
-        }
+        $this->causedBy = $auth->guard($this->authDriver)->user();
 
         $this->logName = $config['activitylog']['default_log_name'];
 

--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\ServiceProvider;
 use Spatie\Activitylog\Contracts\Activity;
 use Spatie\Activitylog\Exceptions\InvalidConfiguration;
 use Spatie\Activitylog\Models\Activity as ActivityModel;
+use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 
 class ActivitylogServiceProvider extends ServiceProvider
 {
@@ -52,7 +53,7 @@ class ActivitylogServiceProvider extends ServiceProvider
         return $activityModel;
     }
 
-    public static function getActivityModelInstance(): Model
+    public static function getActivityModelInstance(): ActivityContract
     {
         $activityModelClassName = self::determineActivityModel();
 

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -31,11 +31,16 @@ trait LogsActivity
                     return;
                 }
 
-                app(ActivityLogger::class)
+                $logger = app(ActivityLogger::class)
                     ->useLog($logName)
                     ->performedOn($model)
-                    ->withProperties($model->attributeValuesToBeLogged($eventName))
-                    ->log($description);
+                    ->withProperties($model->attributeValuesToBeLogged($eventName));
+
+                if (method_exists($model, 'tapActivity')) {
+                    $logger->tap([$model, 'tapActivity'], $eventName);
+                }
+
+                $logger->log($description);
             });
         });
     }

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -285,7 +285,7 @@ class ActivityLoggerTest extends TestCase
         ];
 
         activity()
-            ->tap(function(Activity $activity) use ($properties) {
+            ->tap(function (Activity $activity) use ($properties) {
                 $activity->properties = collect($properties);
                 $activity->created_at = Carbon::yesterday()->startOfDay();
             })

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -9,7 +9,7 @@ use Spatie\Activitylog\Test\Models\User;
 use Spatie\Activitylog\Test\Models\Article;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
 
-class ActivityloggerTest extends TestCase
+class ActivityLoggerTest extends TestCase
 {
     /** @var string */
     protected $activityDescription;


### PR DESCRIPTION
**solves:** #462

I've done some more things - because I wasn't able to do a `tap()` without an activity model instance I've changed all other methods to also work direct on the model. This has a major change, but not breaking, the properties are set on the model in the moment they are called and not just at the end.
I've also cleaned up some things (laravel 5.1 checks, type-hints).
All unit-tests still pass without any change, so I would say that nothing is broken and this just introduces the new feature.