### PR TITLE
Add scope to activity table

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -42,4 +42,9 @@ return [
      * used by the Activity model shipped with this package.
      */
     'table_name' => 'activity_log',
+
+    /*
+     * White list any additional table columns you want to use here.
+     */
+    'scope_fields' => [],
 ];

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -35,6 +35,7 @@ trait LogsActivity
                     ->useLog($logName)
                     ->performedOn($model)
                     ->withProperties($model->attributeValuesToBeLogged($eventName))
+                    ->withScope($model->logScope())
                     ->log($description);
             });
         });
@@ -122,5 +123,10 @@ trait LogsActivity
 
         //do not log update event if only ignored attributes are changed
         return (bool) count(array_except($this->getDirty(), $this->attributesToBeIgnored()));
+    }
+
+    protected function logScope(): array
+    {
+        return [];
     }
 }

--- a/tests/ActivityScopeTest.php
+++ b/tests/ActivityScopeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Spatie\Activitylog\Test;
+
+use AddScopesToActivityLogTable;
+use Spatie\Activitylog\Test\Models\Article;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class ActivityScopeTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->addScopesToActivityLogTable();
+    }
+
+    protected function addScopesToActivityLogTable()
+    {
+        include_once __DIR__.'/migrations/add_scopes_to_activity_log_table.php';
+
+        (new AddScopesToActivityLogTable())->up();
+    }
+
+    /** @test */
+    public function it_can_log_additional_scope_for_event()
+    {
+        $this->app['config']->set('activitylog.scope_fields', ['user_id']);
+
+        $articleClass = new class() extends Article {
+            use LogsActivity;
+
+            protected function logScope(): array
+            {
+                return [
+                    'user_id' => 123,
+                ];
+            }
+        };
+        $article = $articleClass::create();
+
+        $this->assertEquals(123, $this->getLastActivity()->user_id);
+    }
+
+    /** @test */
+    public function it_can_ignore_not_configured_scopes()
+    {
+        $this->app['config']->set('activitylog.scope_fields', []);
+
+        $articleClass = new class() extends Article {
+            use LogsActivity;
+
+            protected function logScope(): array
+            {
+                return [
+                    'user_id' => 123,
+                ];
+            }
+        };
+        $article = $articleClass::create();
+
+        $this->assertNull($this->getLastActivity()->user_id);
+    }
+}

--- a/tests/migrations/add_scopes_to_activity_log_table.php
+++ b/tests/migrations/add_scopes_to_activity_log_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddScopesToActivityLogTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table(config('activitylog.table_name'), function (Blueprint $table) {
+            $table->integer('user_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::table(config('activitylog.table_name'), function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+}


### PR DESCRIPTION
In many cases I want to be able to scope activity log item with some parameter fore simpler fetching later. For example item could be related to the board so scope would be `board_id`.