### PR TITLE
Added optional days argument to clean command

### DIFF
--- a/src/CleanActivitylogCommand.php
+++ b/src/CleanActivitylogCommand.php
@@ -19,7 +19,7 @@ class CleanActivitylogCommand extends Command
         $this->comment('Cleaning activity log...');
 
         $log = $this->argument('log');
-        
+
         $maxAgeInDays = $this->option('days') ?? config('activitylog.delete_records_older_than_days');
 
         $cutOffDate = Carbon::now()->subDays($maxAgeInDays)->format('Y-m-d H:i:s');

--- a/src/CleanActivitylogCommand.php
+++ b/src/CleanActivitylogCommand.php
@@ -10,7 +10,7 @@ class CleanActivitylogCommand extends Command
 {
     protected $signature = 'activitylog:clean
                             {log? : (optional) The log name that will be cleaned.}
-                            {days? : (optional) Records older than this number of days will be cleaned.}';
+                            {--days= : (optional) Records older than this number of days will be cleaned.}';
 
     protected $description = 'Clean up old records from the activity log.';
 
@@ -19,8 +19,8 @@ class CleanActivitylogCommand extends Command
         $this->comment('Cleaning activity log...');
 
         $log = $this->argument('log');
-
-        $maxAgeInDays = $this->argument('days') ?? config('activitylog.delete_records_older_than_days');
+        
+        $maxAgeInDays = $this->option('days') ?? config('activitylog.delete_records_older_than_days');
 
         $cutOffDate = Carbon::now()->subDays($maxAgeInDays)->format('Y-m-d H:i:s');
 

--- a/src/CleanActivitylogCommand.php
+++ b/src/CleanActivitylogCommand.php
@@ -9,7 +9,8 @@ use Illuminate\Database\Eloquent\Builder;
 class CleanActivitylogCommand extends Command
 {
     protected $signature = 'activitylog:clean
-                            {log? : (optional) The log name that will be cleaned.}';
+                            {log? : (optional) The log name that will be cleaned.}
+                            {days? : (optional) Records older than this number of days will be cleaned.}';
 
     protected $description = 'Clean up old records from the activity log.';
 
@@ -19,7 +20,7 @@ class CleanActivitylogCommand extends Command
 
         $log = $this->argument('log');
 
-        $maxAgeInDays = config('activitylog.delete_records_older_than_days');
+        $maxAgeInDays = $this->argument('days') ?? config('activitylog.delete_records_older_than_days');
 
         $cutOffDate = Carbon::now()->subDays($maxAgeInDays)->format('Y-m-d H:i:s');
 

--- a/tests/CleanActivitylogCommandTest.php
+++ b/tests/CleanActivitylogCommandTest.php
@@ -37,4 +37,23 @@ class CleanActivitylogCommandTest extends TestCase
 
         $this->assertCount(0, Activity::where('created_at', '<', $cutOffDate)->get());
     }
+
+    /** @test */
+    public function it_can_accept_days_as_option_to_override_config_setting()
+    {
+        collect(range(1, 60))->each(function (int $index) {
+            Activity::create([
+                'description' => "item {$index}",
+                'created_at' => Carbon::now()->subDays($index)->startOfDay(),
+            ]);
+        });
+
+        $this->assertCount(60, Activity::all());
+
+        Artisan::call('activitylog:clean', ['--days' => 7]);
+
+        $cutOffDate = Carbon::now()->subDay(7)->format('Y-m-d H:i:s');
+
+        $this->assertCount(0, Activity::where('created_at', '<', $cutOffDate)->get());
+    }
 }


### PR DESCRIPTION
Please bear with me, @freekmurze and team! This is my first ever pull request, so I'm hoping I'm following the proper procedure.

I'm requesting we add the ability to set the number of days threshold on the activitylog:clean command if the end user wants to deviate from the default set in the config file. The use case is that you may have multiple logs and want the retention period to be different for each one of them (i.e. user activities are deleted after 7 days where as project activities are deleted after 30 days). 

The end user could then add the activitylog:clean command to their schedule with each variation.