### PR TITLE
Enables to log many to many relations

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -142,7 +142,13 @@ trait DetectsChanges
         list($relatedModelName, $relatedAttribute) = explode('.', $attribute);
 
         $relatedModel = $model->$relatedModelName ?? $model->$relatedModelName();
+        
+        if(is_a($relatedModel, 'Illuminate\Database\Eloquent\Collection')) {
+          $value = $relatedModel->pluck($relatedAttribute)->implode(', ');
+        } else {
+          $value = $relatedModel->$relatedAttribute ?? null;
+        }
 
-        return ["{$relatedModelName}.{$relatedAttribute}" => $relatedModel->$relatedAttribute ?? null];
+        return ["{$relatedModelName}.{$relatedAttribute}" => $value];
     }
 }


### PR DESCRIPTION
If $relatedModel is collection of another models, it just collects $relatedAttribute of each related model and implodes with comma

So if you have many categories on your article, it will return:
``['categories.name' => 'category 1, category 2, category 3']``