### PR TITLE
Control logging when there is no changes

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -32,10 +32,15 @@ trait LogsActivity
                     return;
                 }
 
+                $attrs = $model->attributeValuesToBeLogged($eventName);
+
+                if ($model->logIsEmpty($attrs) && !$model->getSubmitEmptyLogs())
+                    return;
+
                 $logger = app(ActivityLogger::class)
                     ->useLog($logName)
                     ->performedOn($model)
-                    ->withProperties($model->attributeValuesToBeLogged($eventName));
+                    ->withProperties($attrs);
 
                 if (method_exists($model, 'tapActivity')) {
                     $logger->tap([$model, 'tapActivity'], $eventName);
@@ -44,6 +49,16 @@ trait LogsActivity
                 $logger->log($description);
             });
         });
+    }
+
+    public function getSubmitEmptyLogs (): bool
+    {
+        return is_null($this->submitEmptyLogs) ? true : $this->submitEmptyLogs;
+    }
+
+    public function logIsEmpty ($attrs): bool
+    {
+        return !count($attrs['attributes'] ?? []) && !count($attrs['old'] ?? []);
     }
 
     public function disableLogging()

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -59,7 +59,7 @@ trait LogsActivity
 
     public function isLogEmpty($attrs): bool
     {
-        return empty($attrs['attributes'] ?? []) && ! count($attrs['old'] ?? []);
+        return empty($attrs['attributes'] ?? []) && empty($attrs['old'] ?? []);
     }
 
     public function disableLogging()

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -34,8 +34,9 @@ trait LogsActivity
 
                 $attrs = $model->attributeValuesToBeLogged($eventName);
 
-                if ($model->logIsEmpty($attrs) && !$model->getSubmitEmptyLogs())
+                if ($model->isLogEmpty($attrs) && !$model->shuoldSubmitEmptyLogs()) {
                     return;
+                }
 
                 $logger = app(ActivityLogger::class)
                     ->useLog($logName)
@@ -51,12 +52,12 @@ trait LogsActivity
         });
     }
 
-    public function getSubmitEmptyLogs (): bool
+    public function shuoldSubmitEmptyLogs (): bool
     {
-        return is_null($this->submitEmptyLogs) ? true : $this->submitEmptyLogs;
+        return !isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
     }
 
-    public function logIsEmpty ($attrs): bool
+    public function isLogEmpty ($attrs): bool
     {
         return !count($attrs['attributes'] ?? []) && !count($attrs['old'] ?? []);
     }

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -59,7 +59,7 @@ trait LogsActivity
 
     public function isLogEmpty ($attrs): bool
     {
-        return !count($attrs['attributes'] ?? []) && !count($attrs['old'] ?? []);
+        return empty($attrs['attributes'] ?? []) && !count($attrs['old'] ?? []);
     }
 
     public function disableLogging()

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -34,7 +34,7 @@ trait LogsActivity
 
                 $attrs = $model->attributeValuesToBeLogged($eventName);
 
-                if ($model->isLogEmpty($attrs) && !$model->shuoldSubmitEmptyLogs()) {
+                if ($model->isLogEmpty($attrs) && !$model->shouldSubmitEmptyLogs()) {
                     return;
                 }
 
@@ -52,7 +52,7 @@ trait LogsActivity
         });
     }
 
-    public function shuoldSubmitEmptyLogs (): bool
+    public function shouldSubmitEmptyLogs (): bool
     {
         return !isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
     }

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -330,6 +330,27 @@ class LogsActivityTest extends TestCase
         $this->assertEquals(Carbon::yesterday()->startOfDay()->format('Y-m-d H:i:s'), $firstActivity->created_at->format('Y-m-d H:i:s'));
     }
 
+        /** @test */
+    public function it_will_not_submit_log_when_there_is_no_changes()
+    {
+        $model = new class() extends Article {
+            use LogsActivity;
+
+            protected $submitEmptyLogs = false;
+            protected static $logAttributes = ['text'];
+            protected static $logOnlyDirty = true;
+
+        };
+
+        $entity = new $model();
+        $entity->save();
+        $entity->name = 'my name';
+        $entity->save();
+        $activities = $entity->activities;
+        
+        $this->assertCount(1, $activities);
+    }
+
     public function loginWithFakeUser()
     {
         $user = new $this->user();

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -336,7 +336,7 @@ class LogsActivityTest extends TestCase
         $model = new class() extends Article {
             use LogsActivity;
 
-            protected $submitEmptyLogs = false;
+            protected static $submitEmptyLogs = false;
             protected static $logAttributes = ['text'];
             protected static $logOnlyDirty = true;
 
@@ -347,7 +347,7 @@ class LogsActivityTest extends TestCase
         $entity->name = 'my name';
         $entity->save();
         $activities = $entity->activities;
-        
+
         $this->assertCount(1, $activities);
     }
 

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -341,13 +341,15 @@ class LogsActivityTest extends TestCase
             protected static $logOnlyDirty = true;
         };
 
-        $entity = new $model();
+        $entity = new $model(['text' => 'test']);
         $entity->save();
+
+        $this->assertCount(1, Activity::all());
+
         $entity->name = 'my name';
         $entity->save();
-        $activities = $entity->activities;
 
-        $this->assertCount(1, $activities);
+        $this->assertCount(1, Activity::all());
     }
 
     public function loginWithFakeUser()


### PR DESCRIPTION
Sometimes you don't want to save logs that have no changes. 
To use this feature you must set below properties on your model.
```php
            protected static $submitEmptyLogs = false;
            protected static $logOnlyDirty = true;
```