### PR TITLE
Make logStatus available globally

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -46,7 +46,12 @@ class ActivityLogger
 
         return $this;
     }
-
+    
+    public function getLogStatus()
+    {
+        return $this->logStatus;
+    }
+    
     public function performedOn(Model $model)
     {
         $this->getActivity()->subject()->associate($model);


### PR DESCRIPTION
This enables us to check if logStatus is disabled or not globally, as checking enableLoggingModelsEvents is not enough in a global matter when extending your trait.