### PR TITLE
Use new model instead of replicating instance

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -17,7 +17,7 @@ trait DetectsChanges
 
                 //temporary hold the original attributes on the model
                 //as we'll need these in the updating event
-                $oldValues = $model->replicate()->setRawAttributes($model->getOriginal());
+                $oldValues = (new static)->setRawAttributes($model->getOriginal());
 
                 $model->oldAttributes = static::logChanges($oldValues);
             });


### PR DESCRIPTION
1st up: thanks for this package. It's great.

I recently installed this on an existing project and it has caused my application to hit memory allocation limits. All I'm doing is adding the `LogsActivity` trait to some models. 

Running the test suite without `use`ing the trait it runs and consumes `76.25MB` on average during a run. If I `use` the trait it fails at about `536.87 MB` consumed.

I started digging to see if I could find anywhere that might be holding on to references and found 2 places. This is the first.

With this change, my application and suite return to normal. I think this is a sensible change to the package as the replicate method does several things that may not be wanted, and are not needed by this package. 

- It [does a `setRawAttributes`](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Database/Eloquent/Model.php#L1175) which is then duplicated in this library directly after the replicate method is called, making it useless.

- It copies over [all loaded relationships](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Database/Eloquent/Model.php#L1177) on the existing model. Although short lived, there is now another reference to all the models relations.

- It then [fires the `replicating`](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Database/Eloquent/Model.php#L1179) event which triggers the event handler. This doesn't seem like something you would expect this package to be doing anyway. It might also cause an infinite loop if I want to Log replications.

In closing I think that none of the things that happen in the replicating method are relevant to what it is being used for and, memory issue or not, it makes sense to just `new` up a model.

Again, thanks so much for developing and maintaining this package.