### PR TITLE
cleanup old attributes array

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -93,6 +93,8 @@ trait DetectsChanges
             $nullProperties = array_fill_keys(array_keys($properties['attributes']), null);
 
             $properties['old'] = array_merge($nullProperties, $this->oldAttributes);
+
+            $this->oldAttributes = [];
         }
 
         if ($this->shouldLogOnlyDirty() && isset($properties['old'])) {


### PR DESCRIPTION
This is a follow up PR to https://github.com/spatie/laravel-activitylog/pull/537

Although this change does not change the memory usage I'm seeing reported in my test suite, I think it still makes sense for the package to cleanup after itself rather than leaving the old attributes on the model.

Thanks again!