### PR TITLE
Change 'created' to 'updated' to be consistent with the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $newsItem->save();
 $activity = Activity::all()->last();
 
 $activity->description; //returns 'updated'
-$activity->subject; //returns the instance of NewsItem that was created
+$activity->subject; //returns the instance of NewsItem that was updated
 ```
 
 Calling `$activity->changes()` will return this array:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $newsItem->save();
 $activity = Activity::all()->last();
 
 $activity->description; //returns 'updated'
-$activity->subject; //returns the instance of NewsItem that was updated
+$activity->subject; //returns the instance of NewsItem that was saved
 ```
 
 Calling `$activity->changes()` will return this array:


### PR DESCRIPTION
The README example in this section is of an `update` activity. This PR changes the related comment from "returns the instance of NewsItem that was *created*" to "returns the instance of NewsItem that was *updated*" to be consistent with the `update` activity example.