### PR TITLE
Added composite indexes to subject and causer

### DIFF
--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -23,6 +23,8 @@ class CreateActivityLogTable extends Migration
             $table->timestamps();
 
             $table->index('log_name');
+            $table->index(['subject_id', 'subject_type'], 'subject');
+            $table->index(['causer_id', 'causer_type'], 'causer');
         });
     }
 


### PR DESCRIPTION
Today I noticed a significant decrease in performance for the polymorphic subject and causer relationship. I only have about 4.5 million records, so this surprised me. This PR adds a composite index for the causer and also one for the subject. In my case, this increased the performance quite significantly. 

Perhaps this helps others. Also, thank you for the amazing package Spatie :smiley: 

EDIT:
The numbers are as follows:

```SQL
select * from activity_log where subject_id=5749;
```
This returns 10 rows, duration:

```
Duration / Fetch
13,362 sec / 12,262 sec
```

After the migration, I'm executing the exact same query and get these durations:

```
Duration / Fetch
0,053 sec / 0,055 sec
```
