### PR TITLE
don't log activity when disabled in env

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\ActivityLogger;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\ActivityLogStatus;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\ActivitylogServiceProvider;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -18,13 +19,9 @@ trait LogsActivity
 
     protected static function bootLogsActivity()
     {
-        if (! config('activitylog.enabled')) {
-            return;
-        }
-
         static::eventsToBeRecorded()->each(function ($eventName) {
             return static::$eventName(function (Model $model) use ($eventName) {
-                if (! $model->shouldLogEvent($eventName)) {
+                if (! $model->shouldLogEvent($eventName) || $this->activityLoggingDisabled()) {
                     return;
                 }
 
@@ -64,6 +61,11 @@ trait LogsActivity
     public function isLogEmpty($attrs): bool
     {
         return empty($attrs['attributes'] ?? []) && empty($attrs['old'] ?? []);
+    }
+
+    public function activityLoggingDisabled()
+    {
+        return app(ActivityLogStatus::class)->disabled();
     }
 
     public function disableLogging()

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -18,7 +18,7 @@ trait LogsActivity
 
     protected static function bootLogsActivity()
     {
-        if (!config('activitylog.enabled')) {
+        if (! config('activitylog.enabled')) {
             return;
         }
 

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -18,6 +18,10 @@ trait LogsActivity
 
     protected static function bootLogsActivity()
     {
+        if (!config('activitylog.enabled')) {
+            return;
+        }
+
         static::eventsToBeRecorded()->each(function ($eventName) {
             return static::$eventName(function (Model $model) use ($eventName) {
                 if (! $model->shouldLogEvent($eventName)) {


### PR DESCRIPTION
I needed to disable logging when running my test suite, settings         `<env name="ACTIVITY_LOGGER_ENABLED" value="false" />` in phpunit.xml didn't do the trick because the LogsActivity trait doesn't check for this.

This pull request adds that check.