### PR TITLE
Added backward support for non JSON based DBs

### DIFF
--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -19,7 +19,11 @@ class CreateActivityLogTable extends Migration
             $table->string('subject_type')->nullable();
             $table->unsignedBigInteger('causer_id')->nullable();
             $table->string('causer_type')->nullable();
-            $table->json('properties')->nullable();
+            if ((DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') && version_compare(DB::connection()->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION), '5.7.8', 'ge')) {
+                $table->json('properties')->nullable();
+            } else {
+                $table->text('properties')->nullable();
+            }
             $table->timestamps();
 
             $table->index('log_name');


### PR DESCRIPTION
Few Databases, like that one that comes by default with XAMPP, doesn't yet support JSON. This workaround used the text datatype instead of JSON when it's not supported. This is a basic change, but further modifications are welcome.