### PR TITLE
Fix conflict with laravel-translatable

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -126,7 +126,7 @@ trait DetectsChanges
             if (Str::contains($attribute, '.')) {
                 $changes += self::getRelatedModelAttributeValue($model, $attribute);
             } else {
-                $changes[$attribute] = $model->getAttribute($attribute);
+                $changes[$attribute] = $model->attributes[$attribute];
 
                 if (
                     in_array($attribute, $model->getDates())


### PR DESCRIPTION
Working with `laravel-activitylog` + `laravel-translatable`, changes in translatable fields do not get logged.

This allows `laravel-activitylog` to log translatable fields, the only problem that `logOnlyDirty` option is not working and instead the entire JSON is stored.

I'll try to make it work as soon as I have a chance.

Thanks for the great package :)