### PR TITLE
Feature/log json attributes

### DIFF
--- a/docs/advanced-usage/logging-model-events.md
+++ b/docs/advanced-usage/logging-model-events.md
@@ -215,7 +215,7 @@ class NewsItem extends Model
 
     protected $fillable = ['preferences', 'name'];
     
-    protected static $logAttributes = ['preferences->notifications->status', 'preferences->avatar_url'];
+    protected static $logAttributes = ['preferences->notifications->status', 'preferences->hero_url'];
     
     protected $casts = [
         'preferences' => 'collection' // casting the JSON database column
@@ -223,7 +223,56 @@ class NewsItem extends Model
 }
 ```
 
-Changing only `preferences->notifications->status` or `preferences->avatar_url` means only the `preferences->notifications->status` or `preferences->avatar_url` attribute will be logged in the activity, and everything else `preferences` will be left out.
+Changing only `preferences->notifications->status` or `preferences->hero_url` means only the `preferences->notifications->status` or `preferences->hero_url` attribute will be logged in the activity, and everything else `preferences` will be left out.
+
+The output of this in a activity entry would be as follows: 
+```php
+
+// Create a news item.
+$newsItem = NewsItem::create([
+    'name' => 'Title',
+    'preferences' => [
+        'notifications' => [
+            'status' => 'on',
+        ],
+        'hero_url' => ''
+    ],
+]);
+
+// Update the json object
+$newsItem->update([
+    'preferences' => [
+        'notifications' => [
+            'status' => 'on',
+        ],
+        'hero_url' => 'http://example.com/hero.png'
+    ],
+]);
+
+$lastActivity = Activity::latest()->first();
+
+$lastActivity->properties->toArray();
+
+// output
+[
+    "attributes" => [
+        "preferences" => [ // the updated values
+            "notifications" => [
+                "status" => "on",
+            ],
+            "hero_url" => "http://example.com/hero.png",
+        ],
+    ],
+    "old" => [
+        "preferences" => [ // the old settings
+            "notifications" => [
+                "status" => "off",
+            ],
+            "hero_url" => "",
+        ],
+    ],
+]
+```
 
 The result in the log entry key for the attribute will be what is in the `$logAttributes`.
 

--- a/docs/advanced-usage/logging-model-events.md
+++ b/docs/advanced-usage/logging-model-events.md
@@ -226,8 +226,8 @@ class NewsItem extends Model
 Changing only `preferences->notifications->status` or `preferences->hero_url` means only the `preferences->notifications->status` or `preferences->hero_url` attribute will be logged in the activity, and everything else `preferences` will be left out.
 
 The output of this in a activity entry would be as follows: 
-```php
 
+```php
 // Create a news item.
 $newsItem = NewsItem::create([
     'name' => 'Title',
@@ -252,7 +252,9 @@ $newsItem->update([
 $lastActivity = Activity::latest()->first();
 
 $lastActivity->properties->toArray();
+```
 
+```php
 // output
 [
     "attributes" => [

--- a/docs/advanced-usage/logging-model-events.md
+++ b/docs/advanced-usage/logging-model-events.md
@@ -200,6 +200,33 @@ class NewsItem extends Model
 Changing only `name` means only the `name` attribute will be logged in the activity, and `text` will be left out.
 
 
+
+## Logging only the specific JSON attributes sub-key
+
+If you would like to log only the changes to a specific JSON objects sub-keys. You can use the same method for logging specific columns with the difference of choosing the json key to log.
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class NewsItem extends Model
+{
+    use LogsActivity;
+
+    protected $fillable = ['preferences', 'name'];
+    
+    protected static $logAttributes = ['preferences->notifications->status', 'preferences->avatar_url'];
+    
+    protected $casts = [
+        'preferences' => 'collection' // casting the JSON database column
+    ];
+}
+```
+
+Changing only `preferences->notifications->status` or `preferences->avatar_url` means only the `preferences->notifications->status` or `preferences->avatar_url` attribute will be logged in the activity, and everything else `preferences` will be left out.
+
+The result in the log entry key for the attribute will be what is in the `$logAttributes`.
+
 ## Prevent save logs items that have no changed attribute
 
 Setting `$submitEmptyLogs` to `false` prevents the package from storing empty logs. Storing empty logs can happen when you only want to log a certain attribute but only another changes.

--- a/docs/advanced-usage/logging-model-events.md
+++ b/docs/advanced-usage/logging-model-events.md
@@ -201,7 +201,7 @@ Changing only `name` means only the `name` attribute will be logged in the activ
 
 
 
-## Logging only the specific JSON attributes sub-key
+## Logging only a specific JSON attribute sub-key
 
 If you would like to log only the changes to a specific JSON objects sub-keys. You can use the same method for logging specific columns with the difference of choosing the json key to log.
 

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -167,7 +167,7 @@ trait DetectsChanges
         $path = explode('->', $attribute);
         $modelAttribute = array_shift($path);
         $modelAttribute = collect($model->getAttribute($modelAttribute));
-        
+
         return data_get($modelAttribute, implode('.', $path));
     }
 }

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Activitylog\Traits;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Exceptions\CouldNotLogChanges;
 
@@ -163,6 +163,7 @@ trait DetectsChanges
         $path = preg_split('/(->)/', $attribute);
         $modelAttribute = array_shift($path);
         $modelAttribute = collect($model->getAttribute($modelAttribute));
+
         return Arr::get($modelAttribute->toArray() ?? [], implode('.', $path));
     }
 }

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -1143,6 +1143,176 @@ class DetectsChangesTest extends TestCase
         $this->assertSame($expectedChanges, $changes);
     }
 
+    /** @test */
+    public function it_will_return_null_for_missing_json_attribute()
+    {
+        $articleClass = new class() extends Article {
+            protected static $logAttributes = ['name', 'json->data->missing'];
+            public static $logOnlyDirty = true;
+            protected $casts = [
+                'json' => 'collection',
+            ];
+
+            use LogsActivity;
+        };
+
+        $jsonToStore = [];
+
+        $article = new $articleClass();
+        $article->json = $jsonToStore;
+        $article->name = 'I am JSON';
+        $article->save();
+        
+        data_set($jsonToStore, 'data.missing', 'I wasn\'t here');
+
+        $article->json = $jsonToStore;
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'json' =>  [
+                    'data' => [
+                        'missing' => 'I wasn\'t here',
+                    ],
+                ],
+            ],
+            'old' => [
+                'json' =>  [
+                    'data' => [
+                        'missing' => null,
+                    ],
+                ],
+            ],
+        ];
+
+        $changes = $this->getLastActivity()->changes()->toArray();
+
+        $this->assertSame($expectedChanges, $changes);
+    }
+
+    /** @test */
+    public function it_will_return_an_array_for_sub_key_in_json_attribute()
+    {
+        $articleClass = new class() extends Article {
+            protected static $logAttributes = ['name', 'json->data'];
+            public static $logOnlyDirty = true;
+            protected $casts = [
+                'json' => 'collection',
+            ];
+
+            use LogsActivity;
+        };
+
+        $jsonToStore =  [
+            'data' => [
+                'data_a' => 1,
+                'data_b' => 2,
+                'data_c' => 3,
+                'data_d' => 4,
+                'data_e' => 5,
+            ]
+        ]; 
+
+        $article = new $articleClass();
+        $article->json = $jsonToStore;
+        $article->name = 'I am JSON';
+        $article->save();
+        
+        data_set($jsonToStore, 'data.data_c', 'I Got The Key');
+
+        $article->json = $jsonToStore;
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'json' =>  [
+                    'data' => [
+                        'data_a' => 1,
+                        'data_b' => 2,
+                        'data_c' => 'I Got The Key',
+                        'data_d' => 4,
+                        'data_e' => 5,
+                    ]
+                ],
+            ],
+            'old' => [
+                'json' =>  [
+                    'data' => [
+                        'data_a' => 1,
+                        'data_b' => 2,
+                        'data_c' => 3,
+                        'data_d' => 4,
+                        'data_e' => 5,
+                    ]
+                ],
+            ],
+        ];
+
+        $changes = $this->getLastActivity()->changes()->toArray();
+
+        $this->assertSame($expectedChanges, $changes);
+    }
+
+    /** @test */
+    public function it_will_access_further_than_level_one_json_attribute()
+    {
+        $articleClass = new class() extends Article {
+            protected static $logAttributes = ['name', 'json->data->can->go->how->far'];
+            public static $logOnlyDirty = true;
+            protected $casts = [
+                'json' => 'collection',
+            ];
+
+            use LogsActivity;
+        };
+
+        $jsonToStore = [];
+        // data_set($jsonToStore, 'data.can.go.how.far', 'Data');
+
+        $article = new $articleClass();
+        $article->json = $jsonToStore;
+        $article->name = 'I am JSON';
+        $article->save();
+        
+        data_set($jsonToStore, 'data.can.go.how.far', 'This far');
+
+        $article->json = $jsonToStore;
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'json' =>  [
+                    'data' => [
+                        'can' => [
+                            'go' => [
+                                'how' => [
+                                    'far' => 'This far',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'old' => [
+                'json' =>  [
+                    'data' => [
+                        'can' => [
+                            'go' => [
+                                'how' => [
+                                    'far' => null,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $changes = $this->getLastActivity()->changes()->toArray();
+
+        $this->assertSame($expectedChanges, $changes);
+    }
+
     protected function createArticle(): Article
     {
         $article = new $this->article();

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -1103,9 +1103,6 @@ class DetectsChangesTest extends TestCase
         $changes = $this->getLastActivity()->changes()->toArray();
 
         $this->assertSame($expectedChanges, $changes);
-
-
-   
     } 
 
     /** @test */
@@ -1142,7 +1139,6 @@ class DetectsChangesTest extends TestCase
         $changes = $this->getLastActivity()->changes()->toArray();
 
         $this->assertSame($expectedChanges, $changes);
-   
     } 
 
     protected function createArticle(): Article

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -1162,7 +1162,7 @@ class DetectsChangesTest extends TestCase
         $article->json = $jsonToStore;
         $article->name = 'I am JSON';
         $article->save();
-        
+
         data_set($jsonToStore, 'data.missing', 'I wasn\'t here');
 
         $article->json = $jsonToStore;
@@ -1203,21 +1203,21 @@ class DetectsChangesTest extends TestCase
             use LogsActivity;
         };
 
-        $jsonToStore =  [
+        $jsonToStore = [
             'data' => [
                 'data_a' => 1,
                 'data_b' => 2,
                 'data_c' => 3,
                 'data_d' => 4,
                 'data_e' => 5,
-            ]
-        ]; 
+            ],
+        ];
 
         $article = new $articleClass();
         $article->json = $jsonToStore;
         $article->name = 'I am JSON';
         $article->save();
-        
+
         data_set($jsonToStore, 'data.data_c', 'I Got The Key');
 
         $article->json = $jsonToStore;
@@ -1232,7 +1232,7 @@ class DetectsChangesTest extends TestCase
                         'data_c' => 'I Got The Key',
                         'data_d' => 4,
                         'data_e' => 5,
-                    ]
+                    ],
                 ],
             ],
             'old' => [
@@ -1243,7 +1243,7 @@ class DetectsChangesTest extends TestCase
                         'data_c' => 3,
                         'data_d' => 4,
                         'data_e' => 5,
-                    ]
+                    ],
                 ],
             ],
         ];
@@ -1273,7 +1273,7 @@ class DetectsChangesTest extends TestCase
         $article->json = $jsonToStore;
         $article->name = 'I am JSON';
         $article->save();
-        
+
         data_set($jsonToStore, 'data.can.go.how.far', 'This far');
 
         $article->json = $jsonToStore;

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -1096,14 +1096,16 @@ class DetectsChangesTest extends TestCase
         $expectedChanges = [
             'attributes' => [
                 'name' => 'I am JSON',
-                'json->data' => 'test',
+                'json' => [
+                    'data' => 'test',
+                ],
             ],
         ];
 
         $changes = $this->getLastActivity()->changes()->toArray();
 
         $this->assertSame($expectedChanges, $changes);
-    } 
+    }
 
     /** @test */
     public function it_will_not_store_changes_to_untracked_json()
@@ -1139,7 +1141,7 @@ class DetectsChangesTest extends TestCase
         $changes = $this->getLastActivity()->changes()->toArray();
 
         $this->assertSame($expectedChanges, $changes);
-    } 
+    }
 
     protected function createArticle(): Article
     {

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -372,6 +372,53 @@ class LogsActivityTest extends TestCase
         $this->assertCount(1, Activity::all());
     }
 
+    /** @test */
+    public function it_will_submit_a_log_with_json_changes()
+    {
+        $model = new class() extends Article {
+            use LogsActivity;
+
+            protected static $submitEmptyLogs = false;
+            protected static $logAttributes = ['text', 'json->data'];
+            public static $logOnlyDirty = true;
+            protected $casts = [
+                'json' => 'collection',
+            ];
+        };
+
+        $entity = new $model([
+            'text' => 'test',
+            'json' => [
+                'data' => 'oldish',
+            ],
+        ]);
+
+        $entity->save();
+
+        $this->assertCount(1, Activity::all());
+
+        $entity->json = [
+            'data' => 'chips', 
+            'irrelevant' => 'should not be',
+        ];
+        
+        $entity->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'json->data' => 'chips',
+            ],
+            'old' => [
+                'json->data' => 'oldish',
+            ],
+        ];
+
+        $changes = $this->getLastActivity()->changes()->toArray();
+        
+        $this->assertCount(2, Activity::all());
+        $this->assertSame($expectedChanges, $changes);
+    }
+
     public function loginWithFakeUser()
     {
         $user = new $this->user();

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -398,10 +398,10 @@ class LogsActivityTest extends TestCase
         $this->assertCount(1, Activity::all());
 
         $entity->json = [
-            'data' => 'chips', 
+            'data' => 'chips',
             'irrelevant' => 'should not be',
         ];
-        
+
         $entity->save();
 
         $expectedChanges = [
@@ -414,7 +414,7 @@ class LogsActivityTest extends TestCase
         ];
 
         $changes = $this->getLastActivity()->changes()->toArray();
-        
+
         $this->assertCount(2, Activity::all());
         $this->assertSame($expectedChanges, $changes);
     }

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -406,10 +406,14 @@ class LogsActivityTest extends TestCase
 
         $expectedChanges = [
             'attributes' => [
-                'json->data' => 'chips',
+                'json' => [
+                    'data' => 'chips',
+                ],
             ],
             'old' => [
-                'json->data' => 'oldish',
+                'json' => [
+                    'data' => 'oldish',
+                ],
             ],
         ];
 


### PR DESCRIPTION
fixes #274 

This feature will add the functionality to add son sub-key filtering to the `$logAttributes`

It also ignores changes to the rest of the son object if it is changed and not in the logAttributes. This also works for the dirtyOnly setting, it won't save a change if that value didn't experience an update.

When the attribute is stored, I went with just keeping the key as it would be defined by a user. 

i.e. if it is `json->subkey->data` it will be 
```php
[
    "attributes" => [
        "json->subkey->data" => 'value',
     ],
]
```

I think this would just be consistent to what is defined in the Model, and also less overhead changing it to something odd or getting mixed up with model relations.

This is related to the issue #274 where other discussion occurred before this PR.

I have added tests for the changes of this feature. Also updated the documentation to reflect the addition. 

Please let me know what to improve.