### PR TITLE
Feature/snake case relationships

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -150,9 +150,7 @@ trait DetectsChanges
 
         [$relatedModelName, $relatedAttribute] = explode('.', $attribute);
 
-        if (Str::contains($relatedModelName, '_')) {
-            $relatedModelName = Str::camel($relatedModelName);
-        }
+        $relatedModelName = Str::camel($relatedModelName);
 
         $relatedModel = $model->$relatedModelName ?? $model->$relatedModelName();
 

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -150,6 +150,10 @@ trait DetectsChanges
 
         [$relatedModelName, $relatedAttribute] = explode('.', $attribute);
 
+        if (Str::contains($relatedModelName, '_')) {
+            $relatedModelName = Str::camel($relatedModelName);
+        }
+
         $relatedModel = $model->$relatedModelName ?? $model->$relatedModelName();
 
         return ["{$relatedModelName}.{$relatedAttribute}" => $relatedModel->$relatedAttribute ?? null];

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -240,6 +240,11 @@ class DetectsChangesTest extends TestCase
             public static $logAttributes = ['name', 'text', 'snake_user.name'];
 
             use LogsActivity;
+
+            public function snakeUser()
+            {
+                return $this->belongsTo(User::class, 'user_id');
+            }
         };
 
         $user = User::create([

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -233,7 +233,7 @@ class DetectsChangesTest extends TestCase
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
-        /** @test */
+    /** @test */
     public function it_can_store_the_changes_when_updating_a_snake_case_related_model()
     {
         $articleClass = new class() extends Article {

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -233,6 +233,47 @@ class DetectsChangesTest extends TestCase
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
+        /** @test */
+    public function it_can_store_the_changes_when_updating_a_snake_case_related_model()
+    {
+        $articleClass = new class() extends Article {
+            public static $logAttributes = ['name', 'text', 'snake_user.name'];
+
+            use LogsActivity;
+        };
+
+        $user = User::create([
+            'name' => 'a name',
+        ]);
+
+        $anotherUser = User::create([
+            'name' => 'another name',
+        ]);
+
+        $article = $articleClass::create([
+            'name' => 'name',
+            'text' => 'text',
+            'user_id' => $user->id,
+        ]);
+
+        $article->user()->associate($anotherUser)->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'name' => 'name',
+                'text' => 'text',
+                'snakeUser.name' => 'another name',
+            ],
+            'old' => [
+                'name' => 'name',
+                'text' => 'text',
+                'snakeUser.name' => 'a name',
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
     /** @test */
     public function it_can_store_the_dirty_changes_when_updating_a_related_model()
     {

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -14,9 +14,4 @@ class Article extends Model
     {
         return $this->belongsTo(User::class);
     }
-
-    public function SnakeUser()
-    {
-        return $this->belongsTo(User::class, 'user_id');
-    }
 }

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -17,6 +17,6 @@ class Article extends Model
 
     public function SnakeUser()
     {
-    	return $this->belongsTo(User::class, 'user_id');
+        return $this->belongsTo(User::class, 'user_id');
     }
 }

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -14,4 +14,9 @@ class Article extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function SnakeUser()
+    {
+    	return $this->belongsTo(User::class, 'user_id');
+    }
 }


### PR DESCRIPTION
fixes #499 

Addressing issue #499 

snake_cased relationship definitions within `$logAttributes` are now handled correctly.