### PR TITLE
Feature/nullable causer

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -44,6 +44,12 @@ return [
     'table_name' => 'activity_log',
 
     /*
+    * This is the name of the table that will be created by the migrations and
+    * used by the Anonymous activity loggers model shipped with this package.
+    */
+    'anonymous_causers_table_name' => 'activity_loggers',
+
+    /*
      * This is the database connection that will be used by the migration and
      * the Activity model shipped with this package.
      */

--- a/migrations/create_anonymous_causers_table.php.stub
+++ b/migrations/create_anonymous_causers_table.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateAnonymousCausersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::connection(config('activitylog.database_connection'))->create(config('activitylog.anonymous_causers_table_name'), function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::connection(config('activitylog.database_connection'))->dropIfExists(config('activitylog.anonymous_causers_table_name'));
+    }
+}

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -8,6 +8,7 @@ use Illuminate\Auth\AuthManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Config\Repository;
+use Spatie\Activitylog\Models\AnonymousCauser;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
 use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 
@@ -70,6 +71,13 @@ class ActivityLogger
         $this->getActivity()->causer()->associate($model);
 
         return $this;
+    }
+
+    public function causedByAnonymous(string $name)
+    {
+        $anonymousCauser = AnonymousCauser::firstOrCreate(['name' => $name]);
+
+        return $this->causedBy($anonymousCauser);
     }
 
     public function by($modelOrId)

--- a/src/ActivitylogServiceProvider.php
+++ b/src/ActivitylogServiceProvider.php
@@ -26,6 +26,14 @@ class ActivitylogServiceProvider extends ServiceProvider
                 __DIR__.'/../migrations/create_activity_log_table.php.stub' => database_path("/migrations/{$timestamp}_create_activity_log_table.php"),
             ], 'migrations');
         }
+
+        if (! class_exists('CreateAnonymousCausersTable')) {
+            $timestamp = date('Y_m_d_His', time());
+
+            $this->publishes([
+                __DIR__.'/../migrations/create_anonymous_causers_table.php.stub' => database_path("/migrations/{$timestamp}_create_anonymous_causers_table.php"),
+            ], 'migrations');
+        }
     }
 
     public function register()

--- a/src/Models/AnonymousCauser.php
+++ b/src/Models/AnonymousCauser.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Activitylog\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AnonymousCauser extends Model
+{
+    public $guarded = [];
+
+    public function __construct(array $attributes = [])
+    {
+        if (! isset($this->connection)) {
+            $this->setConnection(config('activitylog.database_connection'));
+        }
+
+        if (! isset($this->table)) {
+            $this->setTable(config('activitylog.anonymous_causers_table_name'));
+        }
+
+        parent::__construct($attributes);
+    }
+}

--- a/src/Models/AnonymousCauser.php
+++ b/src/Models/AnonymousCauser.php
@@ -20,4 +20,5 @@ class AnonymousCauser extends Model
 
         parent::__construct($attributes);
     }
+    
 }

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -150,9 +150,7 @@ trait DetectsChanges
 
         [$relatedModelName, $relatedAttribute] = explode('.', $attribute);
 
-        if (Str::contains($relatedModelName, '_')) {
-            $relatedModelName = Str::camel($relatedModelName);
-        }
+        $relatedModelName = Str::camel($relatedModelName);
 
         $relatedModel = $model->$relatedModelName ?? $model->$relatedModelName();
 

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -150,6 +150,10 @@ trait DetectsChanges
 
         [$relatedModelName, $relatedAttribute] = explode('.', $attribute);
 
+        if (Str::contains($relatedModelName, '_')) {
+            $relatedModelName = Str::camel($relatedModelName);
+        }
+
         $relatedModel = $model->$relatedModelName ?? $model->$relatedModelName();
 
         return ["{$relatedModelName}.{$relatedAttribute}" => $relatedModel->$relatedAttribute ?? null];

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -202,7 +202,7 @@ class ActivityLoggerTest extends TestCase
         $userId = 1;
 
         Auth::login(User::find($userId));
-        
+
         $this->assertCount(0, AnonymousCauser::all());
 
         activity()

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\User;
 use Spatie\Activitylog\Test\Models\Article;
+use Spatie\Activitylog\Models\AnonymousCauser;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
 
 class ActivityLoggerTest extends TestCase
@@ -193,6 +194,29 @@ class ActivityLoggerTest extends TestCase
 
         $this->assertInstanceOf(User::class, $this->getLastActivity()->causer);
         $this->assertEquals($userId, $this->getLastActivity()->causer->id);
+    }
+
+    /** @test */
+    public function it_can_log_an_activity_with_an_anonymous_causer()
+    {
+        $userId = 1;
+
+        Auth::login(User::find($userId));
+        
+        $this->assertCount(0, AnonymousCauser::all());
+
+        activity()
+            ->causedByAnonymous('System')
+            ->log($this->activityDescription);
+
+        $firstActivity = Activity::first();
+        $firstAnonymousCauser = AnonymousCauser::first();
+
+        $this->assertCount(1, AnonymousCauser::all());
+
+        $this->assertInstanceOf(AnonymousCauser::class, $firstActivity->causer);
+        $this->assertEquals($firstAnonymousCauser->id, $firstActivity->causer->id);
+        $this->assertEquals('System', $firstActivity->causer->name);
     }
 
     /** @test */

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -240,6 +240,11 @@ class DetectsChangesTest extends TestCase
             public static $logAttributes = ['name', 'text', 'snake_user.name'];
 
             use LogsActivity;
+
+            public function snakeUser()
+            {
+                return $this->belongsTo(User::class, 'user_id');
+            }
         };
 
         $user = User::create([

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -233,7 +233,7 @@ class DetectsChangesTest extends TestCase
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
-        /** @test */
+    /** @test */
     public function it_can_store_the_changes_when_updating_a_snake_case_related_model()
     {
         $articleClass = new class() extends Article {

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -233,6 +233,47 @@ class DetectsChangesTest extends TestCase
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
+        /** @test */
+    public function it_can_store_the_changes_when_updating_a_snake_case_related_model()
+    {
+        $articleClass = new class() extends Article {
+            public static $logAttributes = ['name', 'text', 'snake_user.name'];
+
+            use LogsActivity;
+        };
+
+        $user = User::create([
+            'name' => 'a name',
+        ]);
+
+        $anotherUser = User::create([
+            'name' => 'another name',
+        ]);
+
+        $article = $articleClass::create([
+            'name' => 'name',
+            'text' => 'text',
+            'user_id' => $user->id,
+        ]);
+
+        $article->user()->associate($anotherUser)->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'name' => 'name',
+                'text' => 'text',
+                'snakeUser.name' => 'another name',
+            ],
+            'old' => [
+                'name' => 'name',
+                'text' => 'text',
+                'snakeUser.name' => 'a name',
+            ],
+        ];
+
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
     /** @test */
     public function it_can_store_the_dirty_changes_when_updating_a_related_model()
     {

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -14,9 +14,4 @@ class Article extends Model
     {
         return $this->belongsTo(User::class);
     }
-
-    public function SnakeUser()
-    {
-        return $this->belongsTo(User::class, 'user_id');
-    }
 }

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -17,6 +17,6 @@ class Article extends Model
 
     public function SnakeUser()
     {
-    	return $this->belongsTo(User::class, 'user_id');
+        return $this->belongsTo(User::class, 'user_id');
     }
 }

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -14,4 +14,9 @@ class Article extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function SnakeUser()
+    {
+    	return $this->belongsTo(User::class, 'user_id');
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Spatie\Activitylog\Test;
 
 use CreateActivityLogTable;
 use Illuminate\Support\Arr;
+use CreateAnonymousCausersTable;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Facades\Schema;
 use Spatie\Activitylog\Models\Activity;
@@ -11,6 +12,7 @@ use Spatie\Activitylog\Test\Models\User;
 use Illuminate\Database\Schema\Blueprint;
 use Spatie\Activitylog\Test\Models\Article;
 use Spatie\Activitylog\ActivitylogServiceProvider;
+use Spatie\Activitylog\Test\Models\AnonymousCauser;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
@@ -58,6 +60,7 @@ abstract class TestCase extends OrchestraTestCase
     protected function setUpDatabase()
     {
         $this->createActivityLogTable();
+        $this->createAnonymousCausersTable();
 
         $this->createTables('articles', 'users');
         $this->seedModels(Article::class, User::class);
@@ -68,6 +71,13 @@ abstract class TestCase extends OrchestraTestCase
         include_once __DIR__.'/../migrations/create_activity_log_table.php.stub';
 
         (new CreateActivityLogTable())->up();
+    }
+
+    protected function createAnonymousCausersTable()
+    {
+        include_once __DIR__.'/../migrations/create_anonymous_causers_table.php.stub';
+
+        (new CreateAnonymousCausersTable())->up();
     }
 
     protected function createTables(...$tableNames)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,6 @@ use Spatie\Activitylog\Test\Models\User;
 use Illuminate\Database\Schema\Blueprint;
 use Spatie\Activitylog\Test\Models\Article;
 use Spatie\Activitylog\ActivitylogServiceProvider;
-use Spatie\Activitylog\Test\Models\AnonymousCauser;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase


### PR DESCRIPTION
As discussed in issue #567 this PR contains a possible "null object" oriented solution to allow anonymous causers. I am open to make changes to this PR. 

There are a couple of things I would like to discuss:
* First of all: is this approach viable anyway?

* What about the name of this null object? For now, I used AnonymousCauser, but I don't know if this is OK.

* Do we need more properties on this null object? For now, I only added 'name'.

* I don't like the inconsistency in config keys 'table_name' and 'anonymous_causers_table_name'. How would you like to tackle this naming?
