### PR TITLE
Feature/anonymous causer

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -59,6 +59,11 @@ class ActivityLogger
         return $this->performedOn($model);
     }
 
+    public function onAnonymous()
+    {
+        return $this->causedByAnonymous();
+    }
+
     public function causedBy($modelOrId)
     {
         if ($modelOrId === null) {
@@ -83,6 +88,11 @@ class ActivityLogger
     public function by($modelOrId)
     {
         return $this->causedBy($modelOrId);
+    }
+
+    public function byAnonymous()
+    {
+        return $this->causedByAnonymous();
     }
 
     public function withProperties($properties)

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -72,17 +72,17 @@ class ActivityLogger
         return $this;
     }
 
+    public function by($modelOrId)
+    {
+        return $this->causedBy($modelOrId);
+    }
+
     public function causedByAnonymous()
     {
         $this->activity->causer_id = null;
         $this->activity->causer_type = null;
 
         return $this;
-    }
-
-    public function by($modelOrId)
-    {
-        return $this->causedBy($modelOrId);
     }
 
     public function byAnonymous()

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -59,11 +59,6 @@ class ActivityLogger
         return $this->performedOn($model);
     }
 
-    public function onAnonymous()
-    {
-        return $this->causedByAnonymous();
-    }
-
     public function causedBy($modelOrId)
     {
         if ($modelOrId === null) {

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -72,6 +72,14 @@ class ActivityLogger
         return $this;
     }
 
+    public function causedByAnonymous()
+    {
+        $this->activity->causer_id = null;
+        $this->activity->causer_type = null;
+
+        return $this;
+    }
+
     public function by($modelOrId)
     {
         return $this->causedBy($modelOrId);

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -195,11 +195,7 @@ class ActivityLoggerTest extends TestCase
         $this->assertEquals($userId, $this->getLastActivity()->causer->id);
     }
 
-    /**
-     * @test
-     *
-     * @requires !Travis
-     */
+    /** @test */
     public function it_can_log_activity_using_an_anonymous_causer()
     {
         activity()

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -218,7 +218,7 @@ class ActivityLoggerTest extends TestCase
         Auth::login(User::find($userId));
 
         activity()
-            ->causedByAnonymous()
+            ->byAnonymous()
             ->log('hello poetsvrouwman');
 
         $this->assertNull($this->getLastActivity()->causer_id);

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -202,8 +202,8 @@ class ActivityLoggerTest extends TestCase
             ->causedByAnonymous()
             ->log('hello poetsvrouwman');
 
-        $this->assertEquals(null, $this->getLastActivity()->causer_id);
-        $this->assertEquals(null, $this->getLastActivity()->causer_type);
+        $this->assertNull($this->getLastActivity()->causer_id);
+        $this->assertNull($this->getLastActivity()->causer_type);
     }
 
     /**

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -206,11 +206,7 @@ class ActivityLoggerTest extends TestCase
         $this->assertNull($this->getLastActivity()->causer_type);
     }
 
-    /**
-     * @test
-     *
-     * @requires !Travis
-     */
+    /** @test */
     public function it_will_override_the_logged_in_user_as_the_causer_when_an_anonymous_causer_is_specified()
     {
         $userId = 1;

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -206,7 +206,6 @@ class ActivityLoggerTest extends TestCase
             ->causedByAnonymous()
             ->log('hello poetsvrouwman');
 
-
         $this->assertEquals(null, $this->getLastActivity()->causer_id);
         $this->assertEquals(null, $this->getLastActivity()->causer_type);
     }
@@ -225,7 +224,6 @@ class ActivityLoggerTest extends TestCase
         activity()
             ->causedByAnonymous()
             ->log('hello poetsvrouwman');
-
 
         $this->assertEquals(null, $this->getLastActivity()->causer_id);
         $this->assertEquals(null, $this->getLastActivity()->causer_type);

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -195,6 +195,42 @@ class ActivityLoggerTest extends TestCase
         $this->assertEquals($userId, $this->getLastActivity()->causer->id);
     }
 
+    /**
+     * @test
+     *
+     * @requires !Travis
+     */
+    public function it_can_log_activity_using_an_anonymous_causer()
+    {
+        activity()
+            ->causedByAnonymous()
+            ->log('hello poetsvrouwman');
+
+
+        $this->assertEquals(null, $this->getLastActivity()->causer_id);
+        $this->assertEquals(null, $this->getLastActivity()->causer_type);
+    }
+
+    /**
+     * @test
+     *
+     * @requires !Travis
+     */
+    public function it_will_override_the_logged_in_user_as_the_causer_when_an_anonymous_causer_is_specified()
+    {
+        $userId = 1;
+
+        Auth::login(User::find($userId));
+
+        activity()
+            ->causedByAnonymous()
+            ->log('hello poetsvrouwman');
+
+
+        $this->assertEquals(null, $this->getLastActivity()->causer_id);
+        $this->assertEquals(null, $this->getLastActivity()->causer_type);
+    }
+
     /** @test */
     public function it_can_replace_the_placeholders()
     {

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -221,8 +221,8 @@ class ActivityLoggerTest extends TestCase
             ->causedByAnonymous()
             ->log('hello poetsvrouwman');
 
-        $this->assertEquals(null, $this->getLastActivity()->causer_id);
-        $this->assertEquals(null, $this->getLastActivity()->causer_type);
+        $this->assertNull($this->getLastActivity()->causer_id);
+        $this->assertNull($this->getLastActivity()->causer_type);
     }
 
     /** @test */


### PR DESCRIPTION
fixes #567 

Adressing the comments by @Gummibeer on previous PR #604 regarding issue #567 

This PR adds a `causedByAnonymous()` method, which can be chained from the `activity()` helper, resolving the `causer_id` and `causer_type` to `null`. 