### PR TITLE
Add section referring to an anonymous causer

### DIFF
--- a/docs/basic-usage/logging-activity.md
+++ b/docs/basic-usage/logging-activity.md
@@ -54,6 +54,8 @@ The `causedBy()`-function has a shorter alias named: `by`
 
 If you're not using `causedBy` the package will automatically use the logged in user.
 
+If you don't want to associate a model as causer of activity, you can use `causedByAnonynmous` (or the shorter alias: `byAnonymous`).
+
 ## Setting custom properties
 
 You can add any property you want to an activity by using `withProperties`


### PR DESCRIPTION
Documented how to the register activies that don't have a specific causer model by using `causedByAnonymous` as described in PR #605