### PR TITLE
Update documentation about "Cleaning up the log"

### DIFF
--- a/docs/basic-usage/cleaning-up-the-log.md
+++ b/docs/basic-usage/cleaning-up-the-log.md
@@ -29,11 +29,3 @@ If you want to clean just one log you can define it as command argument. It will
 ```bash
 php artisan activitylog:clean my_log_channel
 ```
-
-## Overwrite the days to keep per call
-
-You can define the days to keep for each call as command option. This will overwrite the config for this run.
-
-```bash
-php artisan activitylog:clean --days=7
-```


### PR DESCRIPTION
Removed the section "Overwrite the days to keep per call", due to that functionality does not exists anymore.

How to reproduce:

At console
`$ php artisan activitylog:clean --days=1`

Throws the error:
`The "--days" option does not exist.`

File: 
`vendor/spatie/laravel-activitylog/src/CleanActivitylogCommand.php`

Missing the option `days`

```
(...)
class CleanActivitylogCommand extends Command
{
    protected $signature = 'activitylog:clean
                            {log? : (optional) The log name that will be cleaned.}';

    protected $description = 'Clean up old records from the activity log.';
(...)
```