### PR TITLE
Include model's default attribute values in oldAttributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 vendor
 .phpunit.result.cache
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ build
 composer.lock
 vendor
 .phpunit.result.cache
-.idea

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -18,7 +18,8 @@ trait DetectsChanges
 
                 //temporary hold the original attributes on the model
                 //as we'll need these in the updating event
-                $oldValues = (new static)->setRawAttributes($model->getOriginal());
+                $originalAttributes = $model->getOriginal() + $model->fresh()->attributesToArray();
+                $oldValues = (new static)->setRawAttributes($originalAttributes);
 
                 $model->oldAttributes = static::logChanges($oldValues);
             });

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -833,6 +833,22 @@ class DetectsChangesTest extends TestCase
             ],
         ];
         $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+        $user->text = 'my text 1';
+        $user->currency = 'EUR';
+        $user->save();
+        $expectedChanges = [
+            'old' => [
+                'name' => 'my name 1',
+                'text' => 'my text',
+                'currency' => 'USD',
+            ],
+            'attributes' => [
+                'name' => 'my name 1',
+                'text' => 'my text 1',
+                'currency' => 'EUR',
+            ],
+        ];
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
     }
 
     /** @test */

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -14,7 +14,7 @@ class User extends Model implements Authenticatable
 
     protected $guarded = [];
 
-    protected $fillable = ['id', 'name'];
+    protected $fillable = ['id', 'name', 'currency'];
 
     public function getAuthIdentifierName()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -86,6 +86,10 @@ abstract class TestCase extends OrchestraTestCase
                     $table->text('json')->nullable();
                     $table->decimal('price')->nullable();
                 }
+
+                if ($tableName === 'users') {
+                    $table->string('currency')->default('USD');
+                }
             });
         });
     }


### PR DESCRIPTION
### Purpose 
This is an attempt to figure out issue https://github.com/spatie/laravel-activitylog/issues/528. I saw the **help wanted** tag and figured I'd give it a shot. While it is noted in the issue thread that this is something of an edge case, in my experience quite a few devs, including myself, use default values in their databases. And the activity log is technically giving incorrect old values in these cases. 

### How the fix was accomplished 
There is only one loc change outside of the tests. It uses the php array union operator to add the `fresh` model instance's db attributes to the, already included, call to `getOriginal` method on the model. The main problem, as stated by @Gummibeer in the issue thread, is that:

> eloquent doesn't refresh the model after a save. So the currency attributes stays null after creation. That's why the column occurs [null] all the time in the changes.

This PR corrects that issue and displays the model property's default value instead of `null`. 

### Alternative solutions 
A comment by @therour [in the issue thread](https://github.com/spatie/laravel-activitylog/issues/528#issuecomment-509668201), explains that devs can avoid this problem if they include the default value in the `$attributes` property of the model. The only drawback is that with this option the developer needs to manually keep their migrations and model `$attribute` default values in sync. 

### Tests
I've included a new test to confirm the changes work as expected and ran all of the current tests in the test suite to assure that they are still passing after the change. I've also made some minor modifications to current tests, `TestCase` and the `User` model within the test models. Nearly all of the test changes should be credited to @Gummibeer as I used [his PR](https://github.com/spatie/laravel-activitylog/pull/530) to determine how the test should work. 

### Unrelated (possibly important) 
I added `.idea` to the `gitignore` file as I did not want to commit my IDE's idea files since they would not be of use and would muddy the commit. 