### PR TITLE
Update requirements.md

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -5,6 +5,6 @@ weight: 3
 
 The activitylog package requires **PHP 7.1+** and **Laravel 5.2 or higher**. 
 
-The latest version requires **Laravel 5.5**.
+The latest version requires **PHP 7.2+** and **Laravel 5.8 or higher**.
 
 If you're stuck on older version of the framework take a look at [v2](https://docs.spatie.be/laravel-activitylog/v2) or [v1](https://docs.spatie.be/laravel-activitylog/v2) of this package.


### PR DESCRIPTION
Hi 👋

I noticed the docs mentioned Laravel 5.5 as the minimum requirement for the latest version. The latest release `v3.9.1` requires at least 5.8 and PHP 7.2+.