### PR TITLE
Match requirement to composer.json

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -5,6 +5,6 @@ weight: 3
 
 The activitylog package requires **PHP 7.1+** and **Laravel 5.2 or higher**. 
 
-The latest version requires **PHP 7.2+** and **Laravel 5.8 or higher**.
+The latest version requires **PHP 7.2+** and **Laravel 6 or higher**.
 
 If you're stuck on older version of the framework take a look at [v2](https://docs.spatie.be/laravel-activitylog/v2) or [v1](https://docs.spatie.be/laravel-activitylog/v2) of this package.


### PR DESCRIPTION
Composer requires Laravel ^6.0
since release https://github.com/spatie/laravel-activitylog/releases/tag/3.9.2