### PR TITLE
Use getRawOriginal instead of getOriginal

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -18,7 +18,7 @@ trait DetectsChanges
 
                 //temporary hold the original attributes on the model
                 //as we'll need these in the updating event
-                $oldValues = (new static)->setRawAttributes($model->getOriginal());
+                $oldValues = (new static)->setRawAttributes($model->getRawOriginal());
 
                 $model->oldAttributes = static::logChanges($oldValues);
             });

--- a/tests/DetectsChangesTest.php
+++ b/tests/DetectsChangesTest.php
@@ -396,12 +396,45 @@ class DetectsChangesTest extends TestCase
     }
 
     /** @test */
-    public function it_can_store_the_changes_of_array_casted_properties()
+    public function it_can_store_the_changes_of_collection_casted_properties()
     {
         $articleClass = new class() extends Article {
             public static $logAttributes = ['json'];
             public static $logOnlyDirty = true;
             protected $casts = ['json' => 'collection'];
+
+            use LogsActivity;
+        };
+
+        $article = $articleClass::create([
+            'json' => ['value' => 'original'],
+        ]);
+
+        $article->json = collect(['value' => 'updated']);
+        $article->save();
+
+        $expectedChanges = [
+            'attributes' => [
+                'json' => [
+                    'value' => 'updated',
+                ],
+            ],
+            'old' => [
+                'json' => [
+                    'value' => 'original',
+                ],
+            ],
+        ];
+        $this->assertEquals($expectedChanges, $this->getLastActivity()->changes()->toArray());
+    }
+
+    /** @test */
+    public function it_can_store_the_changes_of_array_casted_properties()
+    {
+        $articleClass = new class() extends Article {
+            public static $logAttributes = ['json'];
+            public static $logOnlyDirty = true;
+            protected $casts = ['json' => 'array'];
 
             use LogsActivity;
         };


### PR DESCRIPTION
Fixes #680 

From the Laravel 7 [upgrade guide](https://laravel.com/docs/7.x/upgrade)

> The $model->getOriginal() method will now respect any casts defined on the model. Previously, this method returned the uncast, raw attributes. If you would like to continue retrieving the raw, uncast values, you may use the getRawOriginal method instead.

I used the same test from #681 But this fix seemed easier.