### PR TITLE
Use the `nullableMorphs` blueprint method.

### DIFF
--- a/migrations/create_activity_log_table.php.stub
+++ b/migrations/create_activity_log_table.php.stub
@@ -15,16 +15,11 @@ class CreateActivityLogTable extends Migration
             $table->bigIncrements('id');
             $table->string('log_name')->nullable();
             $table->text('description');
-            $table->unsignedBigInteger('subject_id')->nullable();
-            $table->string('subject_type')->nullable();
-            $table->unsignedBigInteger('causer_id')->nullable();
-            $table->string('causer_type')->nullable();
+            $table->nullableMorphs('subject', 'subject');
+            $table->nullableMorphs('causer', 'causer');
             $table->json('properties')->nullable();
             $table->timestamps();
-
             $table->index('log_name');
-            $table->index(['subject_id', 'subject_type'], 'subject');
-            $table->index(['causer_id', 'causer_type'], 'causer');
         });
     }
 


### PR DESCRIPTION
Since Laravel 5.8, `nullableMorphs` is available as a shortcut method and the package has dropped support for Laravel 5.7 & lower since 3.3 so this should now be used in newer versions.