### PR TITLE
run  attributeValuesToBeLogged  method before getDescripotionForEvent in LogsActivity trait 

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -21,11 +21,15 @@ trait LogsActivity
     {
         static::eventsToBeRecorded()->each(function ($eventName) {
             return static::$eventName(function (Model $model) use ($eventName) {
-                if (! $model->shouldLogEvent($eventName)) {
+                if (!$model->shouldLogEvent($eventName)) {
                     return;
                 }
+                $attrs = $model->attributeValuesToBeLogged($eventName);
 
-                $description = $model->getDescriptionForEvent($eventName);
+                if ($model->isLogEmpty($attrs) && !$model->shouldSubmitEmptyLogs()) {
+                    return;
+                }
+                $description = $model->getDescriptionForEvent($eventName, $attrs);
 
                 $logName = $model->getLogNameToUse($eventName);
 
@@ -33,11 +37,7 @@ trait LogsActivity
                     return;
                 }
 
-                $attrs = $model->attributeValuesToBeLogged($eventName);
 
-                if ($model->isLogEmpty($attrs) && ! $model->shouldSubmitEmptyLogs()) {
-                    return;
-                }
 
                 $logger = app(ActivityLogger::class)
                     ->useLog($logName)
@@ -55,7 +55,7 @@ trait LogsActivity
 
     public function shouldSubmitEmptyLogs(): bool
     {
-        return ! isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
+        return !isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
     }
 
     public function isLogEmpty($attrs): bool
@@ -120,7 +120,7 @@ trait LogsActivity
 
     public function attributesToBeIgnored(): array
     {
-        if (! isset(static::$ignoreChangedAttributes)) {
+        if (!isset(static::$ignoreChangedAttributes)) {
             return [];
         }
 
@@ -131,11 +131,11 @@ trait LogsActivity
     {
         $logStatus = app(ActivityLogStatus::class);
 
-        if (! $this->enableLoggingModelsEvents || $logStatus->disabled()) {
+        if (!$this->enableLoggingModelsEvents || $logStatus->disabled()) {
             return false;
         }
 
-        if (! in_array($eventName, ['created', 'updated'])) {
+        if (!in_array($eventName, ['created', 'updated'])) {
             return true;
         }
 

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -21,12 +21,12 @@ trait LogsActivity
     {
         static::eventsToBeRecorded()->each(function ($eventName) {
             return static::$eventName(function (Model $model) use ($eventName) {
-                if (! $model->shouldLogEvent($eventName)) {
+                if (!$model->shouldLogEvent($eventName)) {
                     return;
                 }
                 $attrs = $model->attributeValuesToBeLogged($eventName);
 
-                if ($model->isLogEmpty($attrs) && ! $model->shouldSubmitEmptyLogs()) {
+                if ($model->isLogEmpty($attrs) && !$model->shouldSubmitEmptyLogs()) {
                     return;
                 }
                 $description = $model->getDescriptionForEvent($eventName, $attrs);
@@ -53,7 +53,7 @@ trait LogsActivity
 
     public function shouldSubmitEmptyLogs(): bool
     {
-        return ! isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
+        return !isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
     }
 
     public function isLogEmpty($attrs): bool
@@ -80,7 +80,7 @@ trait LogsActivity
         return $this->morphMany(ActivitylogServiceProvider::determineActivityModel(), 'subject');
     }
 
-    public function getDescriptionForEvent(string $eventName): string
+    public function getDescriptionForEvent(string $eventName, array $attributes): string
     {
         return $eventName;
     }
@@ -118,7 +118,7 @@ trait LogsActivity
 
     public function attributesToBeIgnored(): array
     {
-        if (! isset(static::$ignoreChangedAttributes)) {
+        if (!isset(static::$ignoreChangedAttributes)) {
             return [];
         }
 
@@ -129,11 +129,11 @@ trait LogsActivity
     {
         $logStatus = app(ActivityLogStatus::class);
 
-        if (! $this->enableLoggingModelsEvents || $logStatus->disabled()) {
+        if (!$this->enableLoggingModelsEvents || $logStatus->disabled()) {
             return false;
         }
 
-        if (! in_array($eventName, ['created', 'updated'])) {
+        if (!in_array($eventName, ['created', 'updated'])) {
             return true;
         }
 

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -21,12 +21,12 @@ trait LogsActivity
     {
         static::eventsToBeRecorded()->each(function ($eventName) {
             return static::$eventName(function (Model $model) use ($eventName) {
-                if (!$model->shouldLogEvent($eventName)) {
+                if (! $model->shouldLogEvent($eventName)) {
                     return;
                 }
                 $attrs = $model->attributeValuesToBeLogged($eventName);
 
-                if ($model->isLogEmpty($attrs) && !$model->shouldSubmitEmptyLogs()) {
+                if ($model->isLogEmpty($attrs) && ! $model->shouldSubmitEmptyLogs()) {
                     return;
                 }
                 $description = $model->getDescriptionForEvent($eventName, $attrs);
@@ -53,7 +53,7 @@ trait LogsActivity
 
     public function shouldSubmitEmptyLogs(): bool
     {
-        return !isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
+        return ! isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
     }
 
     public function isLogEmpty($attrs): bool
@@ -118,7 +118,7 @@ trait LogsActivity
 
     public function attributesToBeIgnored(): array
     {
-        if (!isset(static::$ignoreChangedAttributes)) {
+        if (! isset(static::$ignoreChangedAttributes)) {
             return [];
         }
 
@@ -129,11 +129,11 @@ trait LogsActivity
     {
         $logStatus = app(ActivityLogStatus::class);
 
-        if (!$this->enableLoggingModelsEvents || $logStatus->disabled()) {
+        if (! $this->enableLoggingModelsEvents || $logStatus->disabled()) {
             return false;
         }
 
-        if (!in_array($eventName, ['created', 'updated'])) {
+        if (! in_array($eventName, ['created', 'updated'])) {
             return true;
         }
 

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -21,12 +21,12 @@ trait LogsActivity
     {
         static::eventsToBeRecorded()->each(function ($eventName) {
             return static::$eventName(function (Model $model) use ($eventName) {
-                if (!$model->shouldLogEvent($eventName)) {
+                if (! $model->shouldLogEvent($eventName)) {
                     return;
                 }
                 $attrs = $model->attributeValuesToBeLogged($eventName);
 
-                if ($model->isLogEmpty($attrs) && !$model->shouldSubmitEmptyLogs()) {
+                if ($model->isLogEmpty($attrs) && ! $model->shouldSubmitEmptyLogs()) {
                     return;
                 }
                 $description = $model->getDescriptionForEvent($eventName, $attrs);
@@ -55,7 +55,7 @@ trait LogsActivity
 
     public function shouldSubmitEmptyLogs(): bool
     {
-        return !isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
+        return ! isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;
     }
 
     public function isLogEmpty($attrs): bool
@@ -120,7 +120,7 @@ trait LogsActivity
 
     public function attributesToBeIgnored(): array
     {
-        if (!isset(static::$ignoreChangedAttributes)) {
+        if (! isset(static::$ignoreChangedAttributes)) {
             return [];
         }
 
@@ -131,11 +131,11 @@ trait LogsActivity
     {
         $logStatus = app(ActivityLogStatus::class);
 
-        if (!$this->enableLoggingModelsEvents || $logStatus->disabled()) {
+        if (! $this->enableLoggingModelsEvents || $logStatus->disabled()) {
             return false;
         }
 
-        if (!in_array($eventName, ['created', 'updated'])) {
+        if (! in_array($eventName, ['created', 'updated'])) {
             return true;
         }
 

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -37,8 +37,6 @@ trait LogsActivity
                     return;
                 }
 
-
-
                 $logger = app(ActivityLogger::class)
                     ->useLog($logName)
                     ->performedOn($model)

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -261,7 +261,7 @@ class LogsActivityTest extends TestCase
             use LogsActivity;
             use SoftDeletes;
 
-            public function getDescriptionForEvent(string $eventName): string
+            public function getDescriptionForEvent(string $eventName ,array $attributes): string
             {
                 return ":causer.name $eventName";
             }

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -261,7 +261,7 @@ class LogsActivityTest extends TestCase
             use LogsActivity;
             use SoftDeletes;
 
-            public function getDescriptionForEvent(string $eventName ,array $attributes): string
+            public function getDescriptionForEvent(string $eventName, array $attributes): string
             {
                 return ":causer.name $eventName";
             }


### PR DESCRIPTION
in this PR  i thank we can run attributeValuesToBeLogged method in trait LogsActivity 
and pass result as second parameter in getDescriptionForEvent which it useful to get Appropriate description for attributes changed    

` $description = $model->getDescriptionForEvent($eventName, $attrs);`