### PR TITLE
Fixes issue #733

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -86,7 +86,7 @@ trait DetectsChanges
 
     public function attributeValuesToBeLogged(string $processingEvent): array
     {
-        if (! count($this->attributesToBeLogged())) {
+        if (! count($this->attributesToBeLogged()) || $processingEvent == 'retrieved') {
             return [];
         }
 


### PR DESCRIPTION
Will fix issue #733. In case of recording the retrieved event, the code tried to get the changed attributes (and somehow generated bad gateway). But there won't be any changes, so imo it would be safe to skip this method.