### PR TITLE
do not call fresh() if retrieved event is processed

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -91,9 +91,13 @@ trait DetectsChanges
         }
 
         $properties['attributes'] = static::logChanges(
-            $this->exists
-                ? $this->fresh() ?? $this
-                : $this
+            $processingEvent == 'retrieved'
+                ? $this
+                : (
+                    $this->exists
+                        ? $this->fresh() ?? $this
+                        : $this
+                )
         );
 
         if (static::eventsToBeRecorded()->contains('updated') && $processingEvent == 'updated') {

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -432,10 +432,12 @@ class LogsActivityTest extends TestCase
         $retrieved = Issue733::whereKey($article->getKey())->first();
         $this->assertTrue($article->is($retrieved));
 
-        $this->assertInstanceOf(get_class($article), $this->getLastActivity()->subject);
-        $this->assertTrue($article->is($this->getLastActivity()->subject));
-        $this->assertEquals('retrieved', $this->getLastActivity()->description);
-        $this->assertEquals('retrieved', $this->getLastActivity()->event);
+        $activity = $this->getLastActivity();
+
+        $this->assertInstanceOf(get_class($article), $activity->subject);
+        $this->assertTrue($article->is($activity->subject));
+        $this->assertEquals('retrieved', $activity->description);
+        $this->assertEquals('retrieved', $activity->event);
     }
 
     public function loginWithFakeUser()

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -437,7 +437,6 @@ class LogsActivityTest extends TestCase
         $this->assertInstanceOf(get_class($article), $activity->subject);
         $this->assertTrue($article->is($activity->subject));
         $this->assertEquals('retrieved', $activity->description);
-        $this->assertEquals('retrieved', $activity->event);
     }
 
     public function loginWithFakeUser()

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Test\Models\Article;
+use Spatie\Activitylog\Test\Models\Issue733;
 use Spatie\Activitylog\Test\Models\User;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -421,6 +422,20 @@ class LogsActivityTest extends TestCase
 
         $this->assertCount(2, Activity::all());
         $this->assertSame($expectedChanges, $changes);
+    }
+
+    /** @test */
+    public function it_will_log_the_retrieval_of_the_model()
+    {
+        $article = Issue733::create(['name' => 'my name']);
+
+        $retrieved = Issue733::whereKey($article->getKey())->first();
+        $this->assertTrue($article->is($retrieved));
+
+        $this->assertInstanceOf(get_class($article), $this->getLastActivity()->subject);
+        $this->assertTrue($article->is($this->getLastActivity()->subject));
+        $this->assertEquals('retrieved', $this->getLastActivity()->description);
+        $this->assertEquals('retrieved', $this->getLastActivity()->event);
     }
 
     public function loginWithFakeUser()

--- a/tests/Models/Issue733.php
+++ b/tests/Models/Issue733.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models;
+
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class Issue733 extends Article
+{
+    use LogsActivity;
+
+    protected static $recordEvents = [
+        'retrieved',
+    ];
+
+    protected static $submitEmptyLogs = false;
+    protected static $logAttributes = ['name'];
+    public static $logOnlyDirty = false;
+}


### PR DESCRIPTION
fixes #733 
replaces #734 