### PR TITLE
allow log for chainable relations

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -176,17 +176,23 @@ trait DetectsChanges
 
     protected static function getRelatedModelAttributeValue(Model $model, string $attribute): array
     {
-        if (substr_count($attribute, '.') > 1) {
-            throw CouldNotLogChanges::invalidAttribute($attribute);
-        }
+        $relatedAttributes = explode('.', $attribute);
 
-        [$relatedModelName, $relatedAttribute] = explode('.', $attribute);
+		$relatedAttribute = last($relatedAttributes);
 
-        $relatedModelName = Str::camel($relatedModelName);
+		$attr = [];
+		foreach ($relatedAttributes as $index => $attribute) {
+			if ($index == sizeof($relatedAttributes) - 1) {
+				break;
+			}
+			$relatedModelName = Str::camel($attribute);
+			$attr[] = $relatedModelName;
+			$model = $model->$relatedModelName ?? $model->$relatedModelName();
+		}
 
-        $relatedModel = $model->$relatedModelName ?? $model->$relatedModelName();
+		$relatedModel = $model;
 
-        return ["{$relatedModelName}.{$relatedAttribute}" => $relatedModel->$relatedAttribute ?? null];
+        return [implode('.', $attr) . '.' . $relatedAttribute => $relatedModel->$relatedAttribute ?? null];
     }
 
     protected static function getModelAttributeJsonValue(Model $model, string $attribute)

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -5,7 +5,6 @@ namespace Spatie\Activitylog\Traits;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Spatie\Activitylog\Exceptions\CouldNotLogChanges;
 
 trait DetectsChanges
 {
@@ -192,7 +191,7 @@ trait DetectsChanges
 
         $relatedModel = $model;
 
-        return [implode('.', $attr) . '.' . $relatedAttribute => $relatedModel->$relatedAttribute ?? null];
+        return [implode('.', $attr).'.'.$relatedAttribute => $relatedModel->$relatedAttribute ?? null];
     }
 
     protected static function getModelAttributeJsonValue(Model $model, string $attribute)

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -191,7 +191,7 @@ trait DetectsChanges
 
         $relatedModel = $model;
 
-        return [implode('.', $attr).'.'.$relatedAttribute => $relatedModel->$relatedAttribute ?? null];
+        return [implode('.', $attr).'.'.$relatedAttribute => (method_exists($relatedModel, $relatedAttribute) ? $relatedModel->$relatedAttribute() : null) ?? $relatedModel->$relatedAttribute ?? null];
     }
 
     protected static function getModelAttributeJsonValue(Model $model, string $attribute)

--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -178,19 +178,19 @@ trait DetectsChanges
     {
         $relatedAttributes = explode('.', $attribute);
 
-		$relatedAttribute = last($relatedAttributes);
+        $relatedAttribute = last($relatedAttributes);
 
-		$attr = [];
-		foreach ($relatedAttributes as $index => $attribute) {
-			if ($index == sizeof($relatedAttributes) - 1) {
-				break;
-			}
-			$relatedModelName = Str::camel($attribute);
-			$attr[] = $relatedModelName;
-			$model = $model->$relatedModelName ?? $model->$relatedModelName();
-		}
+        $attr = [];
+        foreach ($relatedAttributes as $index => $attribute) {
+            if ($index == sizeof($relatedAttributes) - 1) {
+                break;
+            }
+            $relatedModelName = Str::camel($attribute);
+            $attr[] = $relatedModelName;
+            $model = $model->$relatedModelName ?? $model->$relatedModelName();
+        }
 
-		$relatedModel = $model;
+        $relatedModel = $model;
 
         return [implode('.', $attr) . '.' . $relatedAttribute => $relatedModel->$relatedAttribute ?? null];
     }


### PR DESCRIPTION
With this change we can now log chainable relations like this
```php
protected static $logAttributes = ['user.role.name'];
```