### PR TITLE
Allow changes to the attribute data to log per attribute.

### DIFF
--- a/src/Traits/DetectsChanges.php
+++ b/src/Traits/DetectsChanges.php
@@ -149,7 +149,7 @@ trait DetectsChanges
                 continue;
             }
 
-            $changes[$attribute] = $model->getAttribute($attribute);
+            $changes[$attribute] = $model->attributeDataToRecord($attribute) ?? $model->getAttribute($attribute);
 
             if (is_null($changes[$attribute])) {
                 continue;

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -53,6 +53,11 @@ trait LogsActivity
         });
     }
 
+    public function attributeDataToRecord($attribute)
+    {
+        return null;
+    }
+
     public function shouldSubmitEmptyLogs(): bool
     {
         return ! isset(static::$submitEmptyLogs) ? true : static::$submitEmptyLogs;


### PR DESCRIPTION
This is a simple solution to what's happening in #647 
This small change allows anyone to change the data that gets logged per attribute without having to override any classes.
As an example the fix to #647 is to have a function as simple as
```php
    public function attributeDataToRecord($attribute)
    {
        if ($this->isTranslatableAttribute($attribute)) {
            return $this->getTranslations($attribute);
        }
    }
```
exist on any model that uses the translatable trait.
Of course this function could also be set in a trait to apply it to a broader set of models.

Any feedback or other ways of making this easier to maintain with multiple packages would be more than welcome. 😄 