### PR TITLE
Disable logging to certain records depending on value returned at tap function

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -27,6 +27,9 @@ class ActivityLogger
     /** @var \Spatie\Activitylog\ActivityLogStatus */
     protected $logStatus;
 
+    /** @var boolean */
+    protected $temporaryLogStatus;
+
     /** @var \Spatie\Activitylog\Contracts\Activity */
     protected $activity;
 
@@ -126,7 +129,7 @@ class ActivityLogger
 
     public function tap(callable $callback, string $eventName = null)
     {
-        call_user_func($callback, $this->getActivity(), $eventName);
+        $this->temporaryLogStatus = call_user_func($callback, $this->getActivity(), $eventName);
 
         return $this;
     }
@@ -147,6 +150,10 @@ class ActivityLogger
 
     public function log(string $description)
     {
+        if ($this->temporaryLogStatus === true) {
+            return;
+        }
+
         if ($this->logStatus->disabled()) {
             return;
         }


### PR DESCRIPTION
This change allows to avoid logging a record based on certain conditions related to the values its properties. Without calling activity()->disableLogging() which will disable logging for all records from the same model. 
It will return a value on the tapActivity function, which is stored at a local variable that affects the log for only this record. It is validated at the log function to stop the logging. It will not affect current functionality.

For example, in this case, it will not log records that it's type is N or M. The other records with different type values will be logged.
````
public function tapActivity(Activity $activity, string $eventName)
    {
        if (in_array($this->type, ['N', 'M'])) {
            return true;
        }
    }
````

This would be helpfull for an existing app that needs to disable log to certain records(based on properties values) from a model. Instead of adding this logic(disable depending on values) to the app business layer it will stay at activitylog's layer.

Any feedback would be more than welcomed