### PR TITLE
Allow causer to return soft deleted models

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ return [
     'subject_returns_soft_deleted_models' => false,
 
     /*
+     * If set to true, the causer returns soft deleted models.
+     */
+    'causer_returns_soft_deleted_models' => false,
+
+    /*
      * This model will be used to log activity.
      * It should be implements the Spatie\Activitylog\Contracts\Activity interface
      * and extend Illuminate\Database\Eloquent\Model.

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -31,6 +31,11 @@ return [
     'subject_returns_soft_deleted_models' => false,
 
     /*
+     * If set to true, the causer returns soft deleted models.
+     */
+    'causer_returns_soft_deleted_models' => false,
+
+    /*
      * This model will be used to log activity.
      * It should be implements the Spatie\Activitylog\Contracts\Activity interface
      * and extend Illuminate\Database\Eloquent\Model.

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -65,6 +65,11 @@ return [
     'subject_returns_soft_deleted_models' => false,
 
     /*
+     * If set to true, the causer returns soft deleted models.
+     */
+    'causer_returns_soft_deleted_models' => false,
+
+    /*
      * This model will be used to log activity.
      * It should be implements the Spatie\Activitylog\Contracts\Activity interface
      * and extend Illuminate\Database\Eloquent\Model.

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -41,6 +41,10 @@ class Activity extends Model implements ActivityContract
 
     public function causer(): MorphTo
     {
+        if (config('activitylog.causer_returns_soft_deleted_models')) {
+            return $this->morphTo()->withTrashed();
+        }
+
         return $this->morphTo();
     }
 

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -197,21 +197,25 @@ class LogsActivityTest extends TestCase
     {
         $this->app['config']->set('activitylog.causer_returns_soft_deleted_models', true);
 
+        $user = $this->loginWithFakeUser();
+        $user->name = 'Causer Name';
+        $user->save();
+
         $article = $this->createArticle();
-
-        $article->name = 'changed name';
+        $article->name = 'causer soft deleted';
         $article->save();
-
         $article->delete();
+        
+        $user->delete();
 
         $activities = $article->activities;
 
-        $this->assertCount(4, $activities);
+        $this->assertCount(3, $activities);
 
-        $this->assertEquals(get_class($this->article), $this->getLastActivity()->causer_type);
+        $this->assertEquals(get_class($this->user), $this->getLastActivity()->causer_type);
         $this->assertEquals($article->id, $this->getLastActivity()->causer_id);
         $this->assertEquals('deleted', $this->getLastActivity()->description);
-        $this->assertEquals('changed name', $this->getLastActivity()->causer->name);
+        $this->assertEquals('Causer Name', $this->getLastActivity()->causer->name);
     }
 
     /** @test */

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -171,7 +171,7 @@ class LogsActivityTest extends TestCase
     }
 
     /** @test */
-    public function it_can_fetch_soft_deleted_models()
+    public function it_can_fetch_soft_deleted_subject_models()
     {
         $this->app['config']->set('activitylog.subject_returns_soft_deleted_models', true);
 
@@ -190,6 +190,28 @@ class LogsActivityTest extends TestCase
         $this->assertEquals($article->id, $this->getLastActivity()->subject_id);
         $this->assertEquals('deleted', $this->getLastActivity()->description);
         $this->assertEquals('changed name', $this->getLastActivity()->subject->name);
+    }
+
+    /** @test */
+    public function it_can_fetch_soft_deleted_causer_models()
+    {
+        $this->app['config']->set('activitylog.causer_returns_soft_deleted_models', true);
+
+        $article = $this->createArticle();
+
+        $article->name = 'changed name';
+        $article->save();
+
+        $article->delete();
+
+        $activities = $article->activities;
+
+        $this->assertCount(3, $activities);
+
+        $this->assertEquals(get_class($this->article), $this->getLastActivity()->causer_type);
+        $this->assertEquals($article->id, $this->getLastActivity()->causer_id);
+        $this->assertEquals('deleted', $this->getLastActivity()->description);
+        $this->assertEquals('changed name', $this->getLastActivity()->causer->name);
     }
 
     /** @test */

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -206,7 +206,7 @@ class LogsActivityTest extends TestCase
 
         $activities = $article->activities;
 
-        $this->assertCount(3, $activities);
+        $this->assertCount(4, $activities);
 
         $this->assertEquals(get_class($this->article), $this->getLastActivity()->causer_type);
         $this->assertEquals($article->id, $this->getLastActivity()->causer_id);

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -216,6 +216,8 @@ class LogsActivityTest extends TestCase
         $this->assertEquals($article->id, $this->getLastActivity()->causer_id);
         $this->assertEquals('deleted', $this->getLastActivity()->description);
         $this->assertEquals('Causer Name', $this->getLastActivity()->causer->name);
+        
+        $user->restore();
     }
 
     /** @test */

--- a/tests/Models/Activity.php
+++ b/tests/Models/Activity.php
@@ -37,6 +37,10 @@ class Activity extends Model implements ActivityContract
 
     public function causer(): MorphTo
     {
+        if (config('activitylog.causer_returns_soft_deleted_models')) {
+            return $this->morphTo()->withTrashed();
+        }
+
         return $this->morphTo();
     }
 

--- a/tests/Models/AnotherInvalidActivity.php
+++ b/tests/Models/AnotherInvalidActivity.php
@@ -35,6 +35,10 @@ class AnotherInvalidActivity implements ActivityContract
 
     public function causer(): MorphTo
     {
+        if (config('activitylog.causer_returns_soft_deleted_models')) {
+            return $this->morphTo()->withTrashed();
+        }
+
         return $this->morphTo();
     }
 


### PR DESCRIPTION
If the causer references a soft-deleted user model, the activity logger returns an error.  This implements the additional suggestions in https://github.com/spatie/laravel-activitylog/issues/94.