### PR TITLE
Fix typo

### DIFF
--- a/docs/advanced-usage/manipulate-changes-array.md
+++ b/docs/advanced-usage/manipulate-changes-array.md
@@ -17,7 +17,7 @@ class RemoveKeyFromLogChangesPipe implements LoggablePipe
 
     public function handle(EventLogBag $event, Closure $next): EventLogBag
     {
-        Arr::forget($event->changes, ["attributes.{$this->felid}", "old.{$this->felid}"]);
+        Arr::forget($event->changes, ["attributes.{$this->field}", "old.{$this->field}"]);
 
         return $next($event);
     }


### PR DESCRIPTION
Fixed a typo in the docs ($this->felid vs $this->field)