### PR TITLE
Fix UPGRADING documentation to add tables migration

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,13 @@
 ## From v3 to v4
 
+### Update required version and publish migrations
+
+``` bash
+composer require spatie/laravel-activitylog "^4.0.0"
+php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="activitylog-migrations"
+php artisan migrate
+```
+
 ### Model event Logging
 
 - All models now need to define a `getActivitylogOptions()` method to configure and return the models options as a `LogOptions` instance.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,9 +1,12 @@
 ## From v3 to v4
 
-### Update required version and publish migrations
-
 ``` bash
 composer require spatie/laravel-activitylog "^4.0.0"
+```
+
+### Publish migrations & migrate new tables
+
+``` bash
 php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="activitylog-migrations"
 php artisan migrate
 ```


### PR DESCRIPTION
I was trying to upgrade to v4 and I realized, after some tries, that there are new migrations in the new version that should be added. 