### PR TITLE
:sparkles: Add ability to keep LogBatch opened #917

### DIFF
--- a/docs/api/log-batch.md
+++ b/docs/api/log-batch.md
@@ -46,7 +46,7 @@ public function isOpen(): bool;
  * Set uuid for the current open batch, it can be used to keep the batch
  * open throughout multiple requests or in a batch queue job.
  */
-public function setBatch(string $uuid): bool;
+public function setBatch(string $uuid): void;
 ```
 
 ## endBatch

--- a/docs/api/log-batch.md
+++ b/docs/api/log-batch.md
@@ -39,6 +39,16 @@ public function startBatch(): void;
 public function isOpen(): bool;
 ```
 
+## setBatch
+
+```php
+/**
+ * Set uuid for the current open batch, it can be used to keep the batch
+ * open throughout multiple requests or in a batch queue job.
+ */
+public function setBatch(string $uuid): bool;
+```
+
 ## endBatch
 
 ```php

--- a/src/Facades/LogBatch.php
+++ b/src/Facades/LogBatch.php
@@ -9,6 +9,7 @@ use Spatie\Activitylog\LogBatch as ActivityLogBatch;
  * @method static string getUuid()
  * @method static mixed withinBatch(\Closure $callback)
  * @method static void startBatch()
+ * @method static void setBatch(string $uuid): void
  * @method static bool isOpen()
  * @method static void endBatch()
  *

--- a/src/LogBatch.php
+++ b/src/LogBatch.php
@@ -21,6 +21,12 @@ class LogBatch
         return $this->uuid;
     }
 
+    public function setBatch(string $uuid): void
+    {
+        $this->uuid = $uuid;
+        $this->transactions = 1;
+    }
+
     public function withinBatch(Closure $callback): mixed
     {
         $this->startBatch();

--- a/tests/LogBatchTest.php
+++ b/tests/LogBatchTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Activitylog\Test;
 
 use Spatie\Activitylog\Facades\LogBatch;
+use Illuminate\Support\Str;
 
 class LogBatchTest extends TestCase
 {
@@ -77,6 +78,36 @@ class LogBatchTest extends TestCase
         LogBatch::startBatch();
 
         $this->assertNull($uuid);
+    }
+
+    /** @test */
+    public function it_can_have_same_uuid_throughout_multiple_batches()
+    {
+        // UUID for all the jobs bellow
+        $uuid = Str::uuid();
+
+        // Job A
+        LogBatch::startBatch();
+        LogBatch::setBatch($uuid);
+        // work, work, work :dancer::dancer:
+        $jobAUuid = LogBatch::getUuid();
+        LogBatch::endBatch();
+
+        // Job B
+        LogBatch::startBatch();
+        LogBatch::setBatch($uuid);
+        // work, work, work :dancer::dancer:
+        $jobBUuid = LogBatch::getUuid();
+        LogBatch::endBatch();
+
+        // Job C
+        LogBatch::startBatch();
+        LogBatch::setBatch($uuid);
+        // work, work, work :dancer::dancer:
+        $jobCUuid = LogBatch::getUuid();
+        LogBatch::endBatch();
+
+        $this->assertContainsEquals($uuid, [$jobAUuid, $jobBUuid, $jobCUuid]);
     }
 
     /** @test */


### PR DESCRIPTION
This PR introduces new method `LogBatch::setBatch($uuid)` that allows to keep log batch opened during multiple requests/queue jobs. :fire: 

As discussed in #915 and solves #917.

:heavy_check_mark: Add tests.
:memo: Add docs.
:wrench: Add usage example.

Thanks @Gummibeer for suggesting the solution! :rocket: :smile:  