### PR TITLE
Use correct addLogChange trait method in docs

### DIFF
--- a/docs/advanced-usage/manipulate-changes-array.md
+++ b/docs/advanced-usage/manipulate-changes-array.md
@@ -27,7 +27,7 @@ class RemoveKeyFromLogChangesPipe implements LoggablePipe
 ```php
 // ... in your controller/job/middleware
 
-NewsItem::addLogPipe(new RemoveKeyFromLogChangesPipe('name'));
+NewsItem::addLogChange(new RemoveKeyFromLogChangesPipe('name'));
 
 $article = NewsItem::create(['name' => 'new article', 'text' => 'new article text']);
 $article->update(['name' => 'update article', 'text' => 'update article text']);
@@ -66,7 +66,7 @@ class YourPipe implements LoggablePipe
 ```
 
 ```php
-YourModel::addLogPipe(new YourPipe);
+YourModel::addLogChange(new YourPipe);
 ```
 
 ## Useful use cases


### PR DESCRIPTION
Hi, we noticed that the current docs at https://spatie.be/docs/laravel-activitylog/v4/advanced-usage/manipulate-changes-array seem to mention a `Model::addLogPipe()` method which doesn't seem to exist.

I presume this was meant to be `Model::addLogChange()` ?