### PR TITLE
Add support for immutable_date casts

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -350,7 +350,7 @@ trait LogsActivity
             if ($model->hasCast($attribute)) {
                 $cast = $model->getCasts()[$attribute];
 
-                if ($model->isCustomDateTimeCast($cast)) {
+                if ($model->isCustomDateTimeCast($cast) || (method_exists($model, 'isImmutableCustomDateTimeCast') && $model->isImmutableCustomDateTimeCast($cast))) {
                     $changes[$attribute] = $model->asDateTime($changes[$attribute])->format(explode(':', $cast, 2)[1]);
                 }
             }


### PR DESCRIPTION
This PR adds support for immutable_date cast which was added in [Laravel v8.53.0](https://github.com/laravel/framework/releases/tag/v8.53.0).

As the composer constraint is set to `laravel/framework: ^8.0.0` the check is wrapped in the `method_exists`.
I simply duplicated the test for date cast. Not sure whether you'd prefer a data provider in that case.

Let me know what you think.
