### PR TITLE
[Bug] Fix model serialization when using `LogsActivity` with `setDescriptionForEvent()`

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -24,7 +24,7 @@ trait LogsActivity
 
     protected array $oldAttributes = [];
 
-    protected LogOptions $activitylogOptions;
+    protected ?LogOptions $activitylogOptions;
 
     public bool $enableLoggingModelsEvents = true;
 
@@ -86,6 +86,9 @@ trait LogsActivity
                 }
 
                 $logger->log($description);
+
+                // Reset log options so the model can be serialized.
+                $model->activitylogOptions = null;
             });
         });
     }

--- a/tests/LogsActivitySerializationTest.php
+++ b/tests/LogsActivitySerializationTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Activitylog\Test;
+
+use Spatie\Activitylog\Test\Models\ArticleWithLogDescriptionClosure;
+
+class LogsActivitySerializationTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_serialized()
+    {
+        $model = ArticleWithLogDescriptionClosure::create(['name' => 'foo']);
+        
+        $this->assertNotNull(serialize($model));
+    }
+}

--- a/tests/LogsActivitySerializationTest.php
+++ b/tests/LogsActivitySerializationTest.php
@@ -12,5 +12,6 @@ class LogsActivitySerializationTest extends TestCase
         $model = ArticleWithLogDescriptionClosure::create(['name' => 'foo']);
         
         $this->assertNotNull(serialize($model));
+        
     }
 }

--- a/tests/LogsActivitySerializationTest.php
+++ b/tests/LogsActivitySerializationTest.php
@@ -12,6 +12,5 @@ class LogsActivitySerializationTest extends TestCase
         $model = ArticleWithLogDescriptionClosure::create(['name' => 'foo']);
         
         $this->assertNotNull(serialize($model));
-        
     }
 }

--- a/tests/Models/ArticleWithLogDescriptionClosure.php
+++ b/tests/Models/ArticleWithLogDescriptionClosure.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models;
+
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class ArticleWithLogDescriptionClosure extends Article
+{
+    use LogsActivity;
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->setDescriptionForEvent(function ($eventName) {
+                return "$eventName";
+            });
+    }
+}

--- a/tests/Models/ArticleWithLogDescriptionClosure.php
+++ b/tests/Models/ArticleWithLogDescriptionClosure.php
@@ -12,8 +12,6 @@ class ArticleWithLogDescriptionClosure extends Article
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->setDescriptionForEvent(function ($eventName) {
-                return "$eventName";
-            });
+            ->setDescriptionForEvent(function () {});
     }
 }

--- a/tests/Models/ArticleWithLogDescriptionClosure.php
+++ b/tests/Models/ArticleWithLogDescriptionClosure.php
@@ -12,6 +12,8 @@ class ArticleWithLogDescriptionClosure extends Article
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->setDescriptionForEvent(function () {});
+            ->setDescriptionForEvent(function ($eventName) {
+                return $eventName;
+            });
     }
 }


### PR DESCRIPTION
## Description

Models that use the `LogsActivity` trait that set the `setDescriptionForEvent()` callback fail to serialize due to the `LogOptions` being set on the model itself in the [`LogsActivity`](https://github.com/spatie/laravel-activitylog/blob/a23de07a6160897559f7f9ac14fa98d2676d450a/src/Traits/LogsActivity.php#L48) trait, which is breaking the ability to queue these models.

## Example

Setup a model using `LogsActivity`:

```php
class Article extends Model
{
    use LogsActivity;

    public function getActivitylogOptions(): LogOptions
    {
        return LogOptions::defaults()
            ->setDescriptionForEvent(function ($eventName) {
                return $eventName;
            });
    }
}
```

Create the model and attempt to serialize it:

```php
$article = Article::create(['name' => 'foo']);

// Throws exception:
serialize($article);
```

## Fix

I've set the `$activitylogOptions` property to be `nullable`, then clear the property after successfully creating logs.

## Tests

**Failing Test**:

https://github.com/stevebauman/laravel-activitylog/actions/runs/1400590019

**Passing Test**:

https://github.com/stevebauman/laravel-activitylog/actions/runs/1400593577

---

Thanks for your time! Let me know if you need any further information or tests 👍 