### PR TITLE
Allow switching the behauviour of logging soft delete events

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -167,6 +167,11 @@ trait LogsActivity
             return false;
         }
 
+        return $this->shouldLogSoftDeleteChanges($eventName);
+    }
+
+    public function shouldLogSoftDeleteChanges(string $eventName):bool
+    {
         if (! in_array($eventName, ['created', 'updated'])) {
             return true;
         }


### PR DESCRIPTION
Adds a new function for changing the way soft delete events are logged.

As discussed in #979.
