### PR TITLE
Fix docblock comment

### DIFF
--- a/src/LogOptions.php
+++ b/src/LogOptions.php
@@ -43,7 +43,7 @@ class LogOptions
     }
 
     /**
-     * log changes to all the $guarded attributes of the model.
+     * Log all attributes that are not listed in $guarded.
      */
     public function logUnguarded(): self
     {


### PR DESCRIPTION
logUnguarded comment said it logged all `$guarded` attributes.  That's fixed.