### PR TITLE
Fix the incorrect tags on the install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The package will automatically register itself.
 You can publish the migration with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="activitylog-migrations"
+php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="migrations"
 ```
 
 _Note_: The default migration assumes you are using integers for your model IDs. If you are using UUIDs, or some other format, adjust the format of the subject_id and causer_id fields in the published migration before continuing.
@@ -108,7 +108,7 @@ php artisan migrate
 You can optionally publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="activitylog-config"
+php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="config"
 ```
 
 ## Changelog

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,7 +7,7 @@ composer require spatie/laravel-activitylog "^4.0.0"
 ### Publish migrations & migrate new tables
 
 ``` bash
-php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="activitylog-migrations"
+php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="migrations"
 php artisan migrate
 ```
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -18,7 +18,7 @@ After you've configured everything you should clear the application config cache
 You can publish the migration with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="activitylog-migrations"
+php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="migrations"
 ```
 
 After the migration has been published you can create the `activity_log` table by running the migrations:
@@ -30,7 +30,7 @@ php artisan migrate
 You can optionally publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="activitylog-config"
+php artisan vendor:publish --provider="Spatie\Activitylog\ActivitylogServiceProvider" --tag="config"
 ```
 
 This is the contents of the published config file:


### PR DESCRIPTION
- Was `--tag="activitylog-migrations"` and `--tag="activitylog-config"`.
- Should have been `--tag="migrations"` and `--tag="config"`