### PR TITLE
Ability to log only for specific environments

### DIFF
--- a/src/LogOptions.php
+++ b/src/LogOptions.php
@@ -25,7 +25,7 @@ class LogOptions
 
     public array $attributeRawValues = [];
 
-    public array $environments = [];
+    public array $environment = [];
 
     public ?Closure $descriptionForEvent = null;
 
@@ -167,9 +167,9 @@ class LogOptions
         return $this;
     }
 
-    public function environments(...$envs): self
+    public function environment(...$envs): self
     {
-        $this->environments = Arr::flatten($envs);
+        $this->environment = Arr::flatten($envs);
 
         return $this;
     }

--- a/src/LogOptions.php
+++ b/src/LogOptions.php
@@ -3,6 +3,7 @@
 namespace Spatie\Activitylog;
 
 use Closure;
+use Illuminate\Support\Arr;
 
 class LogOptions
 {
@@ -23,6 +24,8 @@ class LogOptions
     public array $dontLogIfAttributesChangedOnly = [];
 
     public array $attributeRawValues = [];
+
+    public array $environments = [];
 
     public ?Closure $descriptionForEvent = null;
 
@@ -160,6 +163,13 @@ class LogOptions
     public function useAttributeRawValues(array $attributes): self
     {
         $this->attributeRawValues = $attributes;
+
+        return $this;
+    }
+
+    public function environments(...$envs): self
+    {
+        $this->environments = Arr::flatten($envs);
 
         return $this;
     }

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -166,7 +166,7 @@ trait LogsActivity
         if (
             ! $this->enableLoggingModelsEvents
             || $logStatus->disabled()
-            || (! empty($this->activitylogOptions->environments) && ! in_array(config('app.env'), $this->activitylogOptions->environments))
+            || (! empty($this->activitylogOptions->environment) && ! in_array(config('app.env'), $this->activitylogOptions->environment))
         ) {
             return false;
         }

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -163,7 +163,11 @@ trait LogsActivity
     {
         $logStatus = app(ActivityLogStatus::class);
 
-        if (! $this->enableLoggingModelsEvents || $logStatus->disabled()) {
+        if (
+            ! $this->enableLoggingModelsEvents
+            || $logStatus->disabled()
+            || (! empty($this->activitylogOptions->environments) && ! in_array(config('app.env'), $this->activitylogOptions->environments))
+        ) {
             return false;
         }
 

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -487,7 +487,7 @@ it('will only log activity for the environments that has been set', function () 
         public function getActivitylogOptions(): LogOptions
         {
             return LogOptions::defaults()
-                ->environments(['staging']);
+                ->environment('staging');
         }
     };
 


### PR DESCRIPTION
This PR will add a new option in what environment/environments logging of model events should be allowed.

```
class NewsItem extends Model
{
    use LogsActivity;

    protected $fillable = ['name', 'text'];

    public function getActivitylogOptions(): LogOptions
    {
        return LogOptions::defaults()
        ->logOnly(['name', 'text'])
        ->environment('staging'); // it can be (['staging', 'local']) or ('staging', 'local')
    }
}
```