### PR TITLE
Add ability to use a custom activity model with the `activity()` helper

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -160,7 +160,6 @@ class ActivityLogger
         if ($this->logStatus->disabled()) {
             return null;
         }
-        
 
         $activity = $this->getActivity();
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -160,6 +160,7 @@ class ActivityLogger
         if ($this->logStatus->disabled()) {
             return null;
         }
+        
 
         $activity = $this->getActivity();
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -213,16 +213,24 @@ class ActivityLogger
         }, $description);
     }
 
+    public function setActivity(ActivityContract $activity): static
+    {
+        $this->activity = $activity;
+
+        $this
+            ->useLog($this->defaultLogName)
+            ->withProperties([])
+            ->causedBy($this->causerResolver->resolve());
+
+        $this->activity->batch_uuid = $this->batch->getUuid();
+
+        return $this;
+    }
+
     protected function getActivity(): ActivityContract
     {
         if (! $this->activity instanceof ActivityContract) {
-            $this->activity = ActivitylogServiceProvider::getActivityModelInstance();
-            $this
-                ->useLog($this->defaultLogName)
-                ->withProperties([])
-                ->causedBy($this->causerResolver->resolve());
-
-            $this->activity->batch_uuid = $this->batch->getUuid();
+            $this->setActivity(ActivitylogServiceProvider::getActivityModelInstance());
         }
 
         return $this->activity;

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -78,12 +78,10 @@ class ActivityLogger
 
     public function causedByAnonymous(): static
     {
-        $this->tap(function (Model $activity) {
+        return $this->tap(function (Model $activity) {
             $activity->causer_id = null;
             $activity->causer_type = null;
         });
-
-        return $this;
     }
 
     public function byAnonymous(): static

--- a/tests/CustomActivityModelTest.php
+++ b/tests/CustomActivityModelTest.php
@@ -3,6 +3,7 @@
 use Spatie\Activitylog\Exceptions\InvalidConfiguration;
 use Spatie\Activitylog\Test\Models\Activity;
 use Spatie\Activitylog\Test\Models\AnotherInvalidActivity;
+use Spatie\Activitylog\Test\Models\CustomActivity;
 use Spatie\Activitylog\Test\Models\InvalidActivity;
 
 beforeEach(function () {
@@ -21,6 +22,14 @@ it('can log activity using a custom model', function () {
     expect($activity->description)->toEqual($this->activityDescription);
 
     expect($activity)->toBeInstanceOf(Activity::class);
+});
+
+it('can log activity when setting a custom model', function () {
+    $activity = activity()->setActivity(new CustomActivity())->log($this->activityDescription);
+
+    expect($activity->description)->toEqual($this->activityDescription);
+
+    expect($activity)->toBeInstanceOf(CustomActivity::class);
 });
 
 it('does not throw an exception when model config is null', function () {

--- a/tests/Models/CustomActivity.php
+++ b/tests/Models/CustomActivity.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models;
+
+class CustomActivity extends Activity
+{
+}


### PR DESCRIPTION
This PR adds the ability to set a custom activity model via the `setActivity()` method.

This allows developers to use custom `Activity` models when using the `activity()` helper, without having them extend the `ActivityLogger` class:

```php
activity()->setActivity(new CustomActivity)->log('message');
```

I've also added the `logName` property to the `ActivityLogger` class to delay retrieval/creation of the `Activity` model, so a custom log name is not lost via:

```php
activity('custom-log')->setActivity(new CustomActivity);
```

This means the log name is set on the activity model when calling `->log()` and not when instantiating a new activity via `activity()`.