### PR TITLE
Tap subject when using the logger

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -166,6 +166,10 @@ class ActivityLogger
             $activity
         );
 
+        if (isset($activity->subject) && method_exists($activity->subject, 'tapActivity')) {
+            $this->tap([$activity->subject, 'tapActivity'], $activity->event ?? '');
+        }
+
         $activity->save();
 
         $this->activity = null;


### PR DESCRIPTION
PR for #1022 

This PR will make it so the activity logger will execute the `tapActivity` handler when performed on a subject that defines one.