### PR TITLE
little typo on the logging-model-events.md page

### DIFF
--- a/docs/advanced-usage/logging-model-events.md
+++ b/docs/advanced-usage/logging-model-events.md
@@ -7,7 +7,7 @@ The package can automatically log events such as when a model is created, update
 
 As a bonus the package will also log the changed attributes for all these events when you define our own options method.
 
-The trait contains an abstract method `getActivitylogOptions()` that you can use to customize options. It needs to return a `LogOptions` instance built form `LogOptions::defaults()` using fluent methods.
+The trait contains an abstract method `getActivitylogOptions()` that you can use to customize options. It needs to return a `LogOptions` instance built from `LogOptions::defaults()` using fluent methods.
 
 The attributes that need to be logged can be defined either by their name or you can put in a wildcard `['*']` to log any attribute that has changed.
 


### PR DESCRIPTION
I think `instance built form` is supposed to say `instance built from` in the third paragraph on the page