### PR TITLE
Use `data_get()` for placeholder replacement instead of `Arr::get()`

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -213,9 +213,7 @@ class ActivityLogger
                 return $match;
             }
 
-            $attributeValue = $attributeValue->toArray();
-
-            return Arr::get($attributeValue, $propertyName, $match);
+            return data_get($attributeValue, $propertyName, $match);
         }, $description);
     }
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -6,7 +6,6 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -230,7 +230,7 @@ it('can replace the placeholders', function () {
 it('can replace the placeholders with object properties and accessors', function () {
     $article = Article::create([
         'name' => 'article name',
-        'user_id' => User::first()->id
+        'user_id' => User::first()->id,
     ]);
 
     $article->foo = new stdClass();

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -227,6 +227,23 @@ it('can replace the placeholders', function () {
     expect($this->getLastActivity()->description)->toEqual($expectedDescription);
 });
 
+it('can replace the placeholders deeply', function () {
+    $article = Article::create(['name' => 'article name']);
+
+    $article->foo = new stdClass();
+    $article->foo->bar = new stdClass();
+    $article->foo->bar->baz = 'zal';
+
+    activity()
+        ->performedOn($article)
+        ->withProperties(['key' => 'value', 'key2' => ['subkey' => 'subvalue']])
+        ->log('Subject name is :subject.name, deeply nested property is :subject.foo.bar.baz');
+
+    $expectedDescription = 'Subject name is article name, deeply nested property is zal';
+
+    expect($this->getLastActivity()->description)->toEqual($expectedDescription);
+});
+
 it('can log an activity with event', function () {
     $article = Article::create(['name' => 'article name']);
     activity()

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -227,8 +227,11 @@ it('can replace the placeholders', function () {
     expect($this->getLastActivity()->description)->toEqual($expectedDescription);
 });
 
-it('can replace the placeholders deeply', function () {
-    $article = Article::create(['name' => 'article name']);
+it('can replace the placeholders with object properties and accessors', function () {
+    $article = Article::create([
+        'name' => 'article name',
+        'user_id' => User::first()->id
+    ]);
 
     $article->foo = new stdClass();
     $article->foo->bar = new stdClass();
@@ -237,9 +240,9 @@ it('can replace the placeholders deeply', function () {
     activity()
         ->performedOn($article)
         ->withProperties(['key' => 'value', 'key2' => ['subkey' => 'subvalue']])
-        ->log('Subject name is :subject.name, deeply nested property is :subject.foo.bar.baz');
+        ->log('Subject name is :subject.name, deeply nested property is :subject.foo.bar.baz, accessor property is :subject.owner_name');
 
-    $expectedDescription = 'Subject name is article name, deeply nested property is zal';
+    $expectedDescription = 'Subject name is article name, deeply nested property is zal, accessor property is name 1';
 
     expect($this->getLastActivity()->description)->toEqual($expectedDescription);
 });

--- a/tests/Models/Article.php
+++ b/tests/Models/Article.php
@@ -10,8 +10,13 @@ class Article extends Model
 
     protected $guarded = [];
 
-    public function User()
+    public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function getOwnerNameAttribute()
+    {
+        return $this->user?->name;
     }
 }


### PR DESCRIPTION
## Description

This PR replaces the usage of `Arr::get()` with `data_get()` for retrieving placeholder values, so model properties (and deeply nested properties) can be logged.

## Problem

In the documentation it states:

> These placeholders will get replaced with the **properties** of the given subject, causer or property.

However, this is not the case, as model properties cannot be reached with placeholders -- only model attributes.

Also, calling `$model->toArray()` inadvertently executes and caches model accessors via the `$appends` property, which can cause unneeded overhead if a developer has configured queries to be executed in these accessors.

This PR resolves the above issues by using Laravel's `data_get()` helper, which reaches into objects (and deeply nested objects) via dot-notated key.