### PR TITLE
Fixes causer not being set on ActivityLog when using a different guard other than Laravel's default

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -21,7 +21,7 @@ return [
 
     /*
      * You can specify an auth driver here that gets user models.
-     * If this is null we'll use the default Laravel auth driver.
+     * If this is null we'll use the current Laravel auth driver.
      */
     'default_auth_driver' => null,
 

--- a/src/CauserResolver.php
+++ b/src/CauserResolver.php
@@ -12,7 +12,7 @@ class CauserResolver
 {
     protected AuthManager $authManager;
 
-    protected string $authDriver;
+    protected string | null $authDriver;
 
     protected Closure | null $resolverOverride = null;
 
@@ -22,7 +22,7 @@ class CauserResolver
     {
         $this->authManager = $authManager;
 
-        $this->authDriver = $config['activitylog']['default_auth_driver'] ?? $this->authManager->getDefaultDriver();
+        $this->authDriver = $config['activitylog']['default_auth_driver'];
     }
 
     public function resolve(Model | int | string | null $subject = null): ?Model


### PR DESCRIPTION
This fixes an issue that can cause the causer to not be applied to an ActivityLog if using any guard other than Laravels default 'web' guard. 

Using `$this->authManager->getDefaultDriver()` forces `$this->authManager->guard($this->authDriver)->user()` in `getDefaultCauser` to use that guard.  This change allows the authManager to return the authenticated user of the current guard. 

For example: When testing and using `Sanctum::actingAs($user)`, which uses the 'sanctum' guard, this would previously use the web guard and not return the authenticated user.

I'm not sure how to apply testing for this. 