### PR TITLE
Add a default value to getExtraProperty

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -14,6 +14,7 @@ jobs:
 
             - name: normalize composer.json
               run: |
+                  composer global config --no-plugins allow-plugins.ergebnis/composer-normalize true
                   composer global require ergebnis/composer-normalize
                   composer normalize
 

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -58,10 +58,10 @@
         }
     },
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "laravel": {

--- a/src/Contracts/Activity.php
+++ b/src/Contracts/Activity.php
@@ -13,7 +13,7 @@ interface Activity
 
     public function causer(): MorphTo;
 
-    public function getExtraProperty(string $propertyName): mixed;
+    public function getExtraProperty(string $propertyName, mixed $defaultValue): mixed;
 
     public function changes(): Collection;
 

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -71,9 +71,9 @@ class Activity extends Model implements ActivityContract
         return $this->morphTo();
     }
 
-    public function getExtraProperty(string $propertyName): mixed
+    public function getExtraProperty(string $propertyName, mixed $defaultValue = null): mixed
     {
-        return Arr::get($this->properties->toArray(), $propertyName);
+        return Arr::get($this->properties->toArray(), $propertyName, $defaultValue);
     }
 
     public function changes(): Collection

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -157,6 +157,7 @@ it('can log activity with a single properties', function () {
 
     expect($firstActivity->properties)->toBeInstanceOf(Collection::class);
     expect($firstActivity->getExtraProperty('key'))->toEqual('value');
+    expect($firstActivity->getExtraProperty('non_existant', 'default value'))->toEqual('default value');
 });
 
 it('can translate a given causer id to an object', function () {

--- a/tests/Models/Activity.php
+++ b/tests/Models/Activity.php
@@ -40,9 +40,9 @@ class Activity extends Model implements ActivityContract
         return $this->morphTo();
     }
 
-    public function getExtraProperty(string $propertyName): mixed
+    public function getExtraProperty(string $propertyName, mixed $defaultValue = null): mixed
     {
-        return Arr::get($this->properties->toArray(), $propertyName);
+        return Arr::get($this->properties->toArray(), $propertyName, $defaultValue);
     }
 
     public function changes(): Collection

--- a/tests/Models/AnotherInvalidActivity.php
+++ b/tests/Models/AnotherInvalidActivity.php
@@ -42,12 +42,12 @@ class AnotherInvalidActivity implements ActivityContract
      * Get the extra properties with the given name.
      *
      * @param string $propertyName
-     *
+     * @param mixed $defaultValue
      * @return mixed
      */
-    public function getExtraProperty(string $propertyName): mixed
+    public function getExtraProperty(string $propertyName, mixed $defaultValue = null): mixed
     {
-        return Arr::get($this->properties->toArray(), $propertyName);
+        return Arr::get($this->properties->toArray(), $propertyName, $defaultValue);
     }
 
     public function changes(): Collection


### PR DESCRIPTION
This adds the ergonomic ability to set a default value for `getExtraProperty` when the key doesn't exist on `properties`.