### PR TITLE
Add missing properties to Activity model

### DIFF
--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -19,6 +19,8 @@ use Spatie\Activitylog\Contracts\Activity as ActivityContract;
  * @property int|null $subject_id
  * @property string|null $causer_type
  * @property int|null $causer_id
+ * @property string|null $event
+ * @property string|null $batch_uuid
  * @property \Illuminate\Support\Collection|null $properties
  * @property \Carbon\Carbon|null $created_at
  * @property \Carbon\Carbon|null $updated_at


### PR DESCRIPTION
Running a phpstan analyse, results in Access to an undefined property Spatie\Activitylog\Models\Activity::$event.
This is due to a missing property on the Activity model, i added both the event and batch_uuid properties 