### PR TITLE
Support non backed enum  & php 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "homepage": "https://github.com/spatie/activitylog",
     "require": {
-        "php": "^8.0|^8.1",
+        "php": "^8.0",
         "illuminate/config": "^8.0 || ^9.0",
         "illuminate/database": "^8.53 || ^9.0",
         "illuminate/support": "^8.0 || ^9.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "homepage": "https://github.com/spatie/activitylog",
     "require": {
-        "php": "^8.0",
+        "php": "^8.0|^8.1",
         "illuminate/config": "^8.0 || ^9.0",
         "illuminate/database": "^8.53 || ^9.0",
         "illuminate/support": "^8.0 || ^9.0",

--- a/src/Actions/ResolveForPropertyValueAction.php
+++ b/src/Actions/ResolveForPropertyValueAction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\Activitylog\Actions;
+
+class ResolveForPropertyValueAction
+{
+    /**
+     * Action that resolve property value of log
+     * that cannot be handled by PHP or This Package
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    public static function execute(mixed $value): mixed
+    {
+        $instance = new static;
+
+        if ($instance->isValueAreEnum($value)) {
+            return $value->value ?? $value->name;
+        }
+
+        return $value;
+    }
+
+    protected function isValueAreEnum($value): bool
+    {
+        if (! function_exists('enum_exists')){
+            return false;
+        }
+
+        $enumNamespace = is_object($value)
+            ? get_class($value)
+            : $value;
+
+        return enum_exists($enumNamespace);
+    }
+}

--- a/src/Actions/ResolveForPropertyValueAction.php
+++ b/src/Actions/ResolveForPropertyValueAction.php
@@ -6,7 +6,7 @@ class ResolveForPropertyValueAction
 {
     /**
      * Action that resolve property value of log
-     * that cannot be handled by PHP or This Package
+     * that cannot be handled by PHP as default
      *
      * @param mixed $value
      * @return mixed
@@ -15,6 +15,9 @@ class ResolveForPropertyValueAction
     {
         $instance = new static;
 
+        /**
+         * Give a fallback value if value not a backed enum
+         */
         if ($instance->isValueAreEnum($value)) {
             return $value->value ?? $value->name;
         }
@@ -28,10 +31,8 @@ class ResolveForPropertyValueAction
             return false;
         }
 
-        $enumNamespace = is_object($value)
-            ? get_class($value)
-            : $value;
+        $enumNamespace = is_object($value) ? get_class($value): $value;
 
-        return enum_exists($enumNamespace);
+        return ! is_array($value) && enum_exists($enumNamespace);
     }
 }

--- a/src/Actions/ResolveForPropertyValueAction.php
+++ b/src/Actions/ResolveForPropertyValueAction.php
@@ -18,14 +18,14 @@ class ResolveForPropertyValueAction
         /**
          * Give a fallback value if value not a backed enum
          */
-        if ($instance->isValueAreEnum($value)) {
+        if ($instance->isValueAnEnum($value)) {
             return $value->value ?? $value->name;
         }
 
         return $value;
     }
 
-    protected function isValueAreEnum($value): bool
+    protected function isValueAnEnum($value): bool
     {
         if (! function_exists('enum_exists')){
             return false;

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use Spatie\Activitylog\Actions\ResolveForPropertyValueAction;
 use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 
 class ActivityLogger
@@ -102,16 +103,14 @@ class ActivityLogger
 
     public function withProperties(mixed $properties): static
     {
-        $this->getActivity()->properties = collect($properties);
+        $this->getActivity()->properties = collect($properties)->map(fn ($value) => ResolveForPropertyValueAction::execute($value));
 
         return $this;
     }
 
     public function withProperty(string $key, mixed $value): static
     {
-        if (is_object($value) && function_exists('enum_exists') && enum_exists(get_class($value))) {
-            $value = $value->value ?? $value->name;
-        }
+        $value = ResolveForPropertyValueAction::execute($value);
 
         $this->getActivity()->properties = $this->getActivity()->properties->put($key, $value);
 

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -109,6 +109,10 @@ class ActivityLogger
 
     public function withProperty(string $key, mixed $value): static
     {
+        if (is_object($value) && function_exists('enum_exists') && enum_exists(get_class($value))) {
+            $value = $value->value ?? $value->name;
+        }
+
         $this->getActivity()->properties = $this->getActivity()->properties->put($key, $value);
 
         return $this;

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -366,7 +366,7 @@ trait LogsActivity
             if ($model->hasCast($attribute)) {
                 $cast = $model->getCasts()[$attribute];
 
-                if(function_exists('enum_exists') && enum_exists($cast)) {
+                if (function_exists('enum_exists') && enum_exists($cast)) {
                     $changes[$attribute] = $model->getStorableEnumValue($changes[$attribute]);
                 }
 

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -17,7 +17,6 @@ use Spatie\Activitylog\ActivityLogStatus;
 use Spatie\Activitylog\Contracts\LoggablePipe;
 use Spatie\Activitylog\EventLogBag;
 use Spatie\Activitylog\LogOptions;
-use UnitEnum;
 
 trait LogsActivity
 {

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -17,6 +17,7 @@ use Spatie\Activitylog\ActivityLogStatus;
 use Spatie\Activitylog\Contracts\LoggablePipe;
 use Spatie\Activitylog\EventLogBag;
 use Spatie\Activitylog\LogOptions;
+use UnitEnum;
 
 trait LogsActivity
 {
@@ -365,6 +366,10 @@ trait LogsActivity
 
             if ($model->hasCast($attribute)) {
                 $cast = $model->getCasts()[$attribute];
+
+                if(function_exists('enum_exists') && enum_exists($cast)) {
+                    $changes[$attribute] = $model->getStorableEnumValue($changes[$attribute]);
+                }
 
                 if ($model->isCustomDateTimeCast($cast) || $model->isImmutableCustomDateTimeCast($cast)) {
                     $changes[$attribute] = $model->asDateTime($changes[$attribute])->format(explode(':', $cast, 2)[1]);

--- a/tests/AbleStoreNonBackedEnumTest.php
+++ b/tests/AbleStoreNonBackedEnumTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\Activitylog\Test;
+
+use Spatie\Activitylog\Test\Enum\NonBackedEnum;
+use Spatie\Activitylog\Test\Models\Activity;
+
+it('can store non backed enum', function () {
+    $description = 'ROLE LOG';
+
+    activity()->withProperty('role', NonBackedEnum::User)->log($description);
+
+    expect(Activity::query()->latest()->first()->description)->toEqual($description);
+});

--- a/tests/AbleStoreNonBackedEnumTest.php
+++ b/tests/AbleStoreNonBackedEnumTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Activitylog\Test;
 
+use Illuminate\Support\Str;
 use Spatie\Activitylog\Test\Enum\NonBackedEnum;
 use Spatie\Activitylog\Test\Models\Activity;
 use Spatie\Activitylog\Test\Models\User;
@@ -20,7 +21,7 @@ it('can store non-backed enum only a property', function () {
     expect($latestActivity->description)->toEqual($description)
         ->and($latestActivity->properties['role'])->toEqual('User');
 })
-    ->skip(! function_exists('enum_exists'), "PHP doesn't support enum");
+    ->skip(! Str::of(PHP_VERSION)->startsWith('8.1'), "PHP doesn't support enum");
 
 it('can store non-backed enum with properties', function () {
     $description = 'ROLE LOG';
@@ -34,4 +35,5 @@ it('can store non-backed enum with properties', function () {
     expect($latestActivity->description)->toEqual($description)
         ->and($latestActivity->properties['role'])->toEqual('User');
 })
-    ->skip(! function_exists('enum_exists'), "PHP doesn't support enum");
+    ->skip(! Str::of(PHP_VERSION)->startsWith('8.1'), "PHP doesn't support enum");
+

--- a/tests/AbleStoreNonBackedEnumTest.php
+++ b/tests/AbleStoreNonBackedEnumTest.php
@@ -8,7 +8,7 @@ use Spatie\Activitylog\Test\Models\User;
 
 afterEach(fn() => Activity::query()->latest()->first()->delete());
 
-it('can store non backed only a property', function () {
+it('can store non-backed enum only a property', function () {
     $description = 'ROLE LOG';
 
     activity()
@@ -21,7 +21,7 @@ it('can store non backed only a property', function () {
         ->and($latestActivity->properties['role'])->toEqual('User');
 });
 
-it('can store non backed with properties', function () {
+it('can store non-backed enum with properties', function () {
     $description = 'ROLE LOG';
 
     activity()

--- a/tests/AbleStoreNonBackedEnumTest.php
+++ b/tests/AbleStoreNonBackedEnumTest.php
@@ -19,7 +19,8 @@ it('can store non-backed enum only a property', function () {
 
     expect($latestActivity->description)->toEqual($description)
         ->and($latestActivity->properties['role'])->toEqual('User');
-});
+})
+    ->skip(! function_exists('enum_exists'), "PHP doesn't support enum");
 
 it('can store non-backed enum with properties', function () {
     $description = 'ROLE LOG';
@@ -32,4 +33,5 @@ it('can store non-backed enum with properties', function () {
 
     expect($latestActivity->description)->toEqual($description)
         ->and($latestActivity->properties['role'])->toEqual('User');
-});
+})
+    ->skip(! function_exists('enum_exists'), "PHP doesn't support enum");

--- a/tests/AbleStoreNonBackedEnumTest.php
+++ b/tests/AbleStoreNonBackedEnumTest.php
@@ -4,11 +4,14 @@ namespace Spatie\Activitylog\Test;
 
 use Spatie\Activitylog\Test\Enum\NonBackedEnum;
 use Spatie\Activitylog\Test\Models\Activity;
+use Spatie\Activitylog\Test\Models\User;
 
 it('can store non backed enum', function () {
     $description = 'ROLE LOG';
 
-    activity()->withProperty('role', NonBackedEnum::User)->log($description);
+    activity()
+        ->performedOn(User::first())
+        ->withProperty('role', NonBackedEnum::User)->log($description);
 
     expect(Activity::query()->latest()->first()->description)->toEqual($description);
 });

--- a/tests/AbleStoreNonBackedEnumTest.php
+++ b/tests/AbleStoreNonBackedEnumTest.php
@@ -6,12 +6,30 @@ use Spatie\Activitylog\Test\Enum\NonBackedEnum;
 use Spatie\Activitylog\Test\Models\Activity;
 use Spatie\Activitylog\Test\Models\User;
 
-it('can store non backed enum', function () {
+afterEach(fn() => Activity::query()->latest()->first()->delete());
+
+it('can store non backed only a property', function () {
     $description = 'ROLE LOG';
 
     activity()
         ->performedOn(User::first())
         ->withProperty('role', NonBackedEnum::User)->log($description);
 
-    expect(Activity::query()->latest()->first()->description)->toEqual($description);
+    $latestActivity = Activity::query()->latest()->first();
+
+    expect($latestActivity->description)->toEqual($description)
+        ->and($latestActivity->properties['role'])->toEqual('User');
+});
+
+it('can store non backed with properties', function () {
+    $description = 'ROLE LOG';
+
+    activity()
+        ->performedOn(User::first())
+        ->withProperties(['role' => NonBackedEnum::User])->log($description);
+
+    $latestActivity = Activity::query()->latest()->first();
+
+    expect($latestActivity->description)->toEqual($description)
+        ->and($latestActivity->properties['role'])->toEqual('User');
 });

--- a/tests/AbleStoreNonBackedEnumTest.php
+++ b/tests/AbleStoreNonBackedEnumTest.php
@@ -21,7 +21,7 @@ it('can store non-backed enum only a property', function () {
     expect($latestActivity->description)->toEqual($description)
         ->and($latestActivity->properties['role'])->toEqual('User');
 })
-    ->skip(! Str::of(PHP_VERSION)->startsWith('8.1'), "PHP doesn't support enum");
+    ->skip(version_compare(PHP_VERSION, '8.1', '<'), "PHP < 8.1 doesn't support enum");
 
 it('can store non-backed enum with properties', function () {
     $description = 'ROLE LOG';
@@ -35,5 +35,5 @@ it('can store non-backed enum with properties', function () {
     expect($latestActivity->description)->toEqual($description)
         ->and($latestActivity->properties['role'])->toEqual('User');
 })
-    ->skip(! Str::of(PHP_VERSION)->startsWith('8.1'), "PHP doesn't support enum");
+    ->skip(version_compare(PHP_VERSION, '8.1', '<'), "PHP < 8.1 doesn't support enum");
 

--- a/tests/Enum/NonBackedEnum.php
+++ b/tests/Enum/NonBackedEnum.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Activitylog\Test\Enum;
 
-enum NonBackedEnum
+Enum NonBackedEnum
 {
     case Admin;
 

--- a/tests/Enum/NonBackedEnum.php
+++ b/tests/Enum/NonBackedEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Enum;
+
+enum NonBackedEnum
+{
+    case Admin;
+
+    case User;
+}

--- a/tests/Enum/NonBackedEnum.php
+++ b/tests/Enum/NonBackedEnum.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Activitylog\Test\Enum;
 
-Enum NonBackedEnum
+enum NonBackedEnum
 {
     case Admin;
 


### PR DESCRIPTION
Hello.

yesterday I opened issue with Bug label, because I'm working with non backed enum, it seems cannot work properly, when logging to the package it will return exception I assume package issue, because I'm working with Laravel 9 it pass the data well

here the issue 
👍 [Activity log cannot produce enum on properties (array)](https://github.com/spatie/laravel-activitylog/issues/1108)

This one the first time to try contribute on Open source project, I hope you can support me, so if I have any mistake / wrong on code side etc let me know and learn and help this community as well.

Thanks.