### PR TITLE
Add PHP 8.2 support to tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["8.1", "8.0"]
+                php: [8.1, 8.0, 8.2]
                 laravel: ["^9.0", "^8.0"]
                 dependency-version: [prefer-lowest, prefer-stable]
 


### PR DESCRIPTION
This PR adds PHP 8.2 support to the tests workflow.