### PR TITLE
Fix for replacePlaceholders with ending dot

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -195,7 +195,7 @@ class ActivityLogger
 
     protected function replacePlaceholders(string $description, ActivityContract $activity): string
     {
-        return preg_replace_callback('/:[a-z0-9._-]+/i', function ($match) use ($activity) {
+        return preg_replace_callback('/:[a-z0-9._-]+(?<![.])/i', function ($match) use ($activity) {
             $match = $match[0];
 
             $attribute = Str::before(Str::after($match, ':'), '.');


### PR DESCRIPTION
I noticed that placeholders at the end of a sentence are not matching. 

':causer.name has updated :properties.updatedFields.'

Removing the last dot works, but is not always nice. 

I would suggest changing the regex a little.