### PR TITLE
Implement Laravel's mass pruning feature 

### DIFF
--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\Contracts\Activity as ActivityContract;
+use Spatie\Activitylog\Traits\AllowsMassPruning;
 
 /**
  * Spatie\Activitylog\Models\Activity.
@@ -40,6 +41,8 @@ use Spatie\Activitylog\Contracts\Activity as ActivityContract;
  */
 class Activity extends Model implements ActivityContract
 {
+    use AllowsMassPruning;
+
     public $guarded = [];
 
     protected $casts = [

--- a/src/Traits/AllowsMassPruning.php
+++ b/src/Traits/AllowsMassPruning.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\Activitylog\Traits;
+
+use Illuminate\Database\Eloquent\MassPrunable;
+
+trait AllowsMassPruning
+{
+    use MassPrunable;
+
+    protected int $prunableMaxAgeInDays;
+    protected ?string $prunableLog;
+
+    public function configureMassPruning(int $maxAgeInDays, ?string $log = null): self
+    {
+        $this->prunableMaxAgeInDays = $maxAgeInDays;
+        $this->prunableLog = $log;
+
+        return $this;
+    }
+
+    public function prunable()
+    {
+        return static::where('created_at', '<', now()->subDays($this->prunableMaxAgeInDays))
+            ->when($this->prunableLog, fn ($query) => $query->where('log_name', $this->prunableLog));
+    }
+}

--- a/tests/CleanActivitylogCommandTest.php
+++ b/tests/CleanActivitylogCommandTest.php
@@ -1,7 +1,8 @@
 <?php
 
 use Carbon\Carbon;
-use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Contracts\Activity;
+use Spatie\Activitylog\Traits\AllowsMassPruning;
 
 beforeEach(function () {
     Carbon::setTestNow(Carbon::create(2016, 1, 1, 00, 00, 00));
@@ -9,40 +10,50 @@ beforeEach(function () {
     app()['config']->set('activitylog.delete_records_older_than_days', 31);
 });
 
-it('can clean the activity log', function () {
-    collect(range(1, 60))->each(function (int $index) {
-        Activity::create([
+it('can clean the activity log', function (Activity $activityImpl) {
+    app()['config']->set('activitylog.activity_model', get_class($activityImpl));
+
+    collect(range(1, 60))->each(function (int $index) use ($activityImpl) {
+        $activityImpl::create([
             'description' => "item {$index}",
             'created_at' => Carbon::now()->subDays($index)->startOfDay(),
         ]);
     });
 
-    expect(Activity::all())->toHaveCount(60);
+    expect($activityImpl::all())->toHaveCount(60);
 
     Artisan::call('activitylog:clean');
 
-    expect(Activity::all())->toHaveCount(31);
+    expect($activityImpl::all())->toHaveCount(31);
 
     $cutOffDate = Carbon::now()->subDays(31)->format('Y-m-d H:i:s');
 
-    expect(Activity::where('created_at', '<', $cutOffDate)->get())->toHaveCount(0);
-});
+    expect($activityImpl::where('created_at', '<', $cutOffDate)->get())->toHaveCount(0);
+})->with([
+    'mass pruning' => fn() => new Spatie\Activitylog\Models\Activity,
+    'regular deletion' => fn() => new Spatie\Activitylog\Test\Models\Activity,
+]);
 
-it('can accept days as option to override config setting', function () {
-    collect(range(1, 60))->each(function (int $index) {
-        Activity::create([
+it('can accept days as option to override config setting', function (Activity $activityImpl) {
+    app()['config']->set('activitylog.activity_model', get_class($activityImpl));
+
+    collect(range(1, 60))->each(function (int $index) use ($activityImpl) {
+        $activityImpl::create([
             'description' => "item {$index}",
             'created_at' => Carbon::now()->subDays($index)->startOfDay(),
         ]);
     });
 
-    expect(Activity::all())->toHaveCount(60);
+    expect($activityImpl::all())->toHaveCount(60);
 
     Artisan::call('activitylog:clean', ['--days' => 7]);
 
-    expect(Activity::all())->toHaveCount(7);
+    expect($activityImpl::all())->toHaveCount(7);
 
     $cutOffDate = Carbon::now()->subDays(7)->format('Y-m-d H:i:s');
 
-    expect(Activity::where('created_at', '<', $cutOffDate)->get())->toHaveCount(0);
-});
+    expect($activityImpl::where('created_at', '<', $cutOffDate)->get())->toHaveCount(0);
+})->with([
+    'mass pruning' => fn() => new Spatie\Activitylog\Models\Activity,
+    'regular deletion' => fn() => new Spatie\Activitylog\Test\Models\Activity,
+]);


### PR DESCRIPTION
With this PR, the `CleanActivitylogCommand.php` (`php artisan activitylog:clean`) gains the ability to use the [Laravel "mass pruning" feature](https://laravel.com/docs/9.x/eloquent#mass-pruning) which uses mass-deletion queries; since the `activity_log` table can contain many (many) rows, I think this is a good practice and could make a huge performance difference.

Since the package allows custom Model for Activity and Laravel's mass pruning method is based on Models, I've kept the current behavior as a fallback: a new `Spatie\Activitylog\Traits\AllowsMassPruning` trait must be used to benefit from the functionality in a custom Model.

I updated the tests; If this PR seems reasonable to you, I will also update the documentation.

This PR has no breaking change.