### PR TITLE
Add indexes to default migration

### DIFF
--- a/database/migrations/create_activity_log_table.php.stub
+++ b/database/migrations/create_activity_log_table.php.stub
@@ -13,7 +13,9 @@ class CreateActivityLogTable extends Migration
             $table->string('log_name')->nullable();
             $table->text('description');
             $table->nullableMorphs('subject', 'subject');
+            $table->index(['subject_id']);
             $table->nullableMorphs('causer', 'causer');
+            $table->index(['causer_id']);
             $table->json('properties')->nullable();
             $table->timestamps();
             $table->index('log_name');


### PR DESCRIPTION
I'm proposing this PR more as an idea to consider. We got error messages that on a page in our admin panel the total query time exceeded 2 seconds (`DB::whenQueryingForLongerThan()`). After a little investigation the problem was that the query to the activity_log table was very slow. The query took about 2 seconds:

<img width="950" alt="Scherm­afbeelding 2023-02-22 om 15 11 15" src="https://user-images.githubusercontent.com/59207045/220645952-c02f5037-aa64-4f70-8375-4b56f9934958.png">

The solution was very simple, adding an index solved the issue almost right away. The app has been live for one week (migration from previous platforms into one new platform) and the activity_log table contains about 540.000 rows. So I just wanted to propose this in a PR to add an index to this table in the stub by default.

Thanks!