### PR TITLE
Handle activity logging with no`AuthManager` more gracefully

### DIFF
--- a/src/CauserResolver.php
+++ b/src/CauserResolver.php
@@ -10,7 +10,7 @@ use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
 
 class CauserResolver
 {
-    protected AuthManager $authManager;
+    protected AuthManager | null $authManager;
 
     protected string | null $authDriver;
 
@@ -18,7 +18,7 @@ class CauserResolver
 
     protected Model | null $causerOverride = null;
 
-    public function __construct(Repository $config, AuthManager $authManager)
+    public function __construct(Repository $config, AuthManager | null $authManager)
     {
         $this->authManager = $authManager;
 
@@ -46,6 +46,10 @@ class CauserResolver
 
     protected function resolveUsingId(int | string $subject): Model
     {
+        if ($this->authManager === null) {
+            throw CouldNotLogActivity::couldNotDetermineUserWithoutAuthManager($subject);
+        }
+
         $guard = $this->authManager->guard($this->authDriver);
 
         $provider = method_exists($guard, 'getProvider') ? $guard->getProvider() : null;
@@ -96,6 +100,10 @@ class CauserResolver
 
     protected function getDefaultCauser(): ?Model
     {
+        if ($this->authManager === null) {
+            return null;
+        }
+
         return $this->authManager->guard($this->authDriver)->user();
     }
 }

--- a/src/Exceptions/CouldNotLogActivity.php
+++ b/src/Exceptions/CouldNotLogActivity.php
@@ -10,4 +10,9 @@ class CouldNotLogActivity extends Exception
     {
         return new static("Could not determine a user with identifier `{$id}`.");
     }
+
+    public static function couldNotDetermineUserWithoutAuthManager($id): self
+    {
+        return new static("Could not determine a user with identifier `{$id}` - there is no AuthManager.");
+    }
 }

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -450,3 +450,14 @@ it('does not log non backed enums in properties', function () {
 })
     ->throws(JsonEncodingException::class)
     ->skip(version_compare(PHP_VERSION, '8.1', '<'), "PHP < 8.1 doesn't support enum");
+
+
+it('logs without having auth manager implementation in the container', function () {
+    // simulates application not having AuthServiceProvider loaded
+    app()->singleton('auth', fn () => null);
+
+    activity()->log($message = 'I can log without the app giving an auth manager to the causer resolver');
+
+    expect($activity = $this->getLastActivity())->toBeInstanceOf(Activity::class);
+    $this->assertSame($message, $activity->description);
+});

--- a/tests/CauserResolverTest.php
+++ b/tests/CauserResolverTest.php
@@ -43,3 +43,16 @@ it('will resolve any model', function () {
     expect($causer)->toBeInstanceOf(Article::class);
     expect($causer->id)->toEqual($article->id);
 });
+
+it('will throw an exception it there is no auth manager to resolve', function () {
+    // simulates application not having AuthServiceProvider loaded
+    app()->singleton('auth', fn () => null);
+
+    $causer = CauserResolver::resolve();
+    expect($causer)->toBeNull();
+
+    $this->expectExceptionObject(CouldNotLogActivity::couldNotDetermineUserWithoutAuthManager($subject = 9999));
+
+    $causer = CauserResolver::resolve($subject);
+    expect($causer)->toBeNull();
+});


### PR DESCRIPTION
I recently installed this package on a project where we are serving an internal microservice API which has no need to have users/auth/cookies, etc.

So we have it so that `AuthServiceProvider` and `CookieServiceProvider` providers aren't being loaded.

<details>
<summary>versions</summary>

* php 8.1
* laravel 9.47.0
* spatie/laravel-activitylog 4.7.3

</details>

When I was doing some activity logging `activity()->log('whatever')` (attempted with `causedBy(null)`, `causedByAnonymous()`, etc.) I was encountering an issue.

```
Target class [auth] does not exist.
```

This PR will resolve this.