### PR TITLE
soft deleted causer

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -31,6 +31,11 @@ return [
     'subject_returns_soft_deleted_models' => false,
 
     /*
+     * If set to true, the causer returns soft deleted models.
+     */
+    'causer_returns_soft_deleted_models' => false,
+
+    /*
      * This model will be used to log activity.
      * It should implement the Spatie\Activitylog\Contracts\Activity interface
      * and extend Illuminate\Database\Eloquent\Model.

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -67,6 +67,11 @@ return [
     'subject_returns_soft_deleted_models' => false,
 
     /*
+     * If set to true, the causer returns soft deleted models.
+     */
+    'causer_returns_soft_deleted_models' => false,
+
+    /*
      * This model will be used to log activity.
      * It should be implements the Spatie\Activitylog\Contracts\Activity interface
      * and extend Illuminate\Database\Eloquent\Model.

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -70,6 +70,10 @@ class Activity extends Model implements ActivityContract
 
     public function causer(): MorphTo
     {
+        if (config('activitylog.causer_returns_soft_deleted_models')) {
+            return $this->morphTo()->withTrashed();
+        }
+
         return $this->morphTo();
     }
 


### PR DESCRIPTION
Hi

I have enabled soft deletes on the causer model in my project. When a causer model is soft deleted, I could not get the causer from the activity log.

This pull request adds a config option to include soft deleted causer models, and adds withTrashed() to the causer method in the Activity model.