### PR TITLE
Allow `shouldLogUnguarded()` to respect `Model::unguard()`

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -247,7 +247,7 @@ trait LogsActivity
 
         // This case means all of the attributes are guarded
         // so we'll not have any unguarded anyway.
-        if (in_array('*', $this->getGuarded())) {
+        if (in_array('*', $this->getGuarded()) && ! static::isUnguarded()) {
             return false;
         }
 


### PR DESCRIPTION
When `Model::unguard()` is used in Laravel projects, it is expected that the developer intends to unguard ALL Models without necessary setting `$guarded = []` across all models.

This PR allows the `shouldLogUnguarded` method on the `LogsActivity` trait to respect `Model::unguard()`;

`shouldLogUnguarded` is expected to return `true` whenever `Model::unguard()` has been invoked, of course, unless `logUguarded` has been explicitly set to `false` on the model's `LogOptions`.

