### PR TITLE
Allow for safer fallback of causer resolver

### DIFF
--- a/src/CauserResolver.php
+++ b/src/CauserResolver.php
@@ -96,6 +96,12 @@ class CauserResolver
 
     protected function getDefaultCauser(): ?Model
     {
-        return $this->authManager->guard($this->authDriver)->user();
+        $user = $this->authManager->guard($this->authDriver)->user();
+
+        if ($user instanceof Model) {
+            return $user;
+        }
+
+        return null;
     }
 }

--- a/tests/CauserResolverTest.php
+++ b/tests/CauserResolverTest.php
@@ -15,13 +15,21 @@ it('can resolve current logged in user', function () {
     expect($causer->id)->toEqual($user->id);
 });
 
+it('will not fail when user is not an instance of Model', function () {
+    Auth::login($user = new \Illuminate\Auth\GenericUser(['id' => 1]));
+
+    $causer = CauserResolver::resolve();
+
+    expect($causer)->toBeNull();
+});
+
 it('will throw an exception if it cannot resolve user by id', function () {
     $this->expectException(CouldNotLogActivity::class);
 
     CauserResolver::resolve(9999);
 });
 
-it('can resloved user from passed id', function () {
+it('can resolved user from passed id', function () {
     $causer = CauserResolver::resolve(1);
 
     expect($causer)->toBeInstanceOf(User::class);


### PR DESCRIPTION
Right now when using non-Eloquent auth provider drivers, things can sometimes break when logging model events. For example, using a simple `token` guard driver and `database` provider driver, the logged in user is an instance of `Illuminate\Auth\GenericUser`. When model events get fired, the user is not an instance of `Model` and is also not null, so a `TypeError` gets thrown. 

This change will make the default resolver more forgiving and will prevent a `TypeError` when the current user is not an instance of `Model`, while still maintaining the ability to override the causer using the normal means. Since `Auth::user()` (which is the the current logic of the default causer resolver) is meant to return an instance of `Illuminate\Contracts\Auth\Authenticatable` rather than `Model`, I think this is a reasonable fallback.