### PR TITLE
feat: Adds mocking/faking of activity logging, and assertions for unit testing.

### DIFF
--- a/docs/advanced-usage/faking-logging.md
+++ b/docs/advanced-usage/faking-logging.md
@@ -1,0 +1,112 @@
+---
+title: Faking logging
+weight: 7
+---
+
+When writing test code, you may wish to 'mock' activity logging. This will allow you to write assertions about the log entries that would have been made, and will aso avoid the performance hit of accessing the database to store the log entries.
+
+Activity logging can be mocked out, or "faked", in the current request by calling
+
+```php
+activity()->fake();
+```
+
+After this log entries will not be written to the database, but you can make assertions about what _would_ have been logged.
+
+```php
+
+activity()->fake();
+
+activity()->log('Look, ma! No database!');
+activity()->log('I can do this all day');
+
+activity()->assertLogged(2);
+activity()->assertLoggedWithDescription('Look, ma! No database!', 1);
+
+```
+
+## Assertions
+
+In a phpunit unit testing context, you can make assertions about what _would_ have been logged, after calling `activity()->fake()`.
+
+You can use these assertions to test whether log entries would have been made, and optionally how many, based on a range of different criteria. The final assertion lets you define your own criteria by passing a callback.
+
+In each case, `$expectedCount` is optional: if you omit it, you are asserting that some (i.e. more than zero) log entries were made that meet the relevant criteria. If you include it, you are asserting that exactly that many log entries were made.
+
+`assertLogged($expectedCount = null)`
+
+Asserts that some activities were logged.
+
+`assertNothingLogged()`
+
+Asserts that no activities were logged.
+
+`assertLoggedToLog(string $logName, int $expectedCount = null)`
+
+`assertNothingLoggedToLog(string $logName)`
+
+Asserts that some/no activities were logged to the specified log.
+
+`assertLoggedWithDescription(string $description, int $expectedCount = null)`
+
+`assertNothingLoggedWithDescription(string $description)`
+
+Asserts that some/no activities were logged with the specified description.
+
+`assertLoggedWithEvent(string $event, int $expectedCount = null)`
+
+`assertNothingLoggedWithEvent(string $event)`
+
+Asserts that some/no activities were logged with the specified event.
+
+`assertLoggedWithSubjectType(string $subjectType, int $expectedCount = null)`
+
+`assertNothingLoggedWithSubjectType(string $subjectType)`
+
+Asserts that some/no activities were logged with the specified subject type.
+
+`assertLoggedWithSubjectId(mixed $subjectId, int $expectedCount = null)`
+
+`assertNothingLoggedWithSubjectId(mixed $subjectId)`
+
+Asserts that no activities were logged with the specified subject id.
+
+`assertLoggedWithCauserType(string $causerType, int $expectedCount = null)`
+
+`assertNothingLoggedWithCauserType(string $causerType)`
+
+Asserts that some/no activities were logged with the specified causer type.
+
+`assertLoggedWithCauserId(mixed $causerId, int $expectedCount = null)`
+
+`assertNothingLoggedWithCauserId(mixed $causerId)`
+
+Asserts that some/no activities were logged with the specified causer id.
+
+`assertLoggedWithProperties(mixed $properties, int $expectedCount = null)`
+
+`assertNothingLoggedWithProperties(mixed $properties)`
+
+Asserts that some/no activities were logged with a set of properties that exactly matches the set of specified properties.
+
+`assertLoggedIncludingProperties(mixed $properties, int $expectedCount = null)`
+
+`assertNothingLoggedIncludingProperties(mixed $properties)`
+
+Asserts that some/no activities were logged with a set of properties that includes the specified properties.
+
+`assertLoggedMatching(Closure $callback, int $expectedCount = null)`
+
+`assertNothingLoggedMatching(Closure $callback)`
+
+Asserts that some/no activities were logged that match the criteria determined by the callback.
+
+The callback will be called once for each activity that was logged. It will receive a single `Activity` instance as its argument. It should return true if that activity matches the criteria, false otherwise.
+
+e.g. to assert that at least one activity was logged with a description of 'Foo' and a subject type of 'Bar':
+
+```php
+activity()->assertLoggedMatching(function (Activity $activity) {
+    return $activity->description === 'Foo' && $activity->subject_type === 'Bar';
+});
+```

--- a/src/ActivityLogFaker.php
+++ b/src/ActivityLogFaker.php
@@ -1,0 +1,347 @@
+<?php
+
+namespace Spatie\Activitylog;
+
+use Closure;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class ActivityLogFaker extends ActivityLogger
+{
+    protected array $loggedActivities = [];
+
+    public function recordActivity($activity)
+    {
+        $this->loggedActivities[] = $activity;
+    }
+
+    public function assertLogged(int $expectedCount = null): void
+    {
+        $activityCount = count($this->loggedActivities);
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                'No activities were logged.',
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLogged(): void
+    {
+        $this->assertLogged(0);
+    }
+
+    public function assertLoggedToLog(string $logName, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount(
+            function ($activity) use ($logName) {
+                return $activity->log_name === $logName;
+            }
+        );
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                "No activities were logged to the log \"{$logName}\".",
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged to the log \"{$logName}\" instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedToLog(string $logName): void
+    {
+        $this->assertLoggedToLog($logName, 0);
+    }
+
+    public function assertLoggedWithDescription(string $description, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount(
+            function ($activity) use ($description) {
+                return $activity->description === $description;
+            }
+        );
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                "No activities were logged with the description \"{$description}\".",
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged with the description \"{$description}\" instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedWithDescription(string $description): void
+    {
+        $this->assertLoggedWithDescription($description, 0);
+    }
+
+    public function assertLoggedWithEvent(string $event, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount(
+            function ($activity) use ($event) {
+                return $activity->event === $event;
+            }
+        );
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                "No activities were logged with the event \"{$event}\".",
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged with the event \"{$event}\" instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedWithEvent(string $event): void
+    {
+        $this->assertLoggedWithEvent($event, 0);
+    }
+
+    public function assertLoggedWithSubjectType(string $subjectType, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount(
+            function ($activity) use ($subjectType) {
+                return $activity->subject_type === $subjectType;
+            }
+        );
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                "No activities were logged on subjects with type \"{$subjectType}\".",
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged on subjects with type \"{$subjectType}\" instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedWithSubjectType(string $subjectType): void
+    {
+        $this->assertLoggedWithSubjectType($subjectType, 0);
+    }
+
+    public function assertLoggedWithSubjectId(mixed $subjectId, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount(
+            function ($activity) use ($subjectId) {
+                return $activity->subject_id === $subjectId;
+            }
+        );
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                "No activities were logged on subjects with id \"{$subjectId}\".",
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged on subjects with id \"{$subjectId}\" instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedWithSubjectId(mixed $subjectId): void
+    {
+        $this->assertLoggedWithSubjectId($subjectId, 0);
+    }
+
+    public function assertLoggedWithCauserType(string $causerType, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount(
+            function ($activity) use ($causerType) {
+                return $activity->causer_type === $causerType;
+            }
+        );
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                "No activities were logged for causers with type \"{$causerType}\".",
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged for causers with type \"{$causerType}\" instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedWithCauserType(string $causerType): void
+    {
+        $this->assertLoggedWithCauserType($causerType, 0);
+    }
+
+    public function assertLoggedWithCauserId(mixed $causerId, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount(
+            function ($activity) use ($causerId) {
+                return $activity->causer_id === $causerId;
+            }
+        );
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                "No activities were logged for causers with id \"{$causerId}\".",
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged for causers with id \"{$causerId}\" instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedWithCauserId(mixed $causerId): void
+    {
+        $this->assertLoggedWithCauserId($causerId, 0);
+    }
+
+    public function assertLoggedWithProperties(mixed $properties, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount(
+            function ($activity) use ($properties) {
+                return
+                    count($activity->properties) === count($properties)
+                    && count($activity->properties->intersect($properties)) === count($properties);
+            }
+        );
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                'No activities were logged with the specified properties.',
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged with the specified properties, instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedWithProperties(mixed $properties): void
+    {
+        $this->assertLoggedWithProperties($properties, 0);
+    }
+
+    public function assertLoggedIncludingProperties(mixed $properties, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount(
+            function ($activity) use ($properties) {
+                return count($activity->properties->intersect($properties)) === count($properties);
+            }
+        );
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                'No activities were logged with the specified properties.',
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged that included the specified properties, instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedIncludingProperties(mixed $properties): void
+    {
+        $this->assertLoggedIncludingProperties($properties, 0);
+    }
+
+    public function assertLoggedMatching(Closure $callback, int $expectedCount = null): void
+    {
+        $activityCount = $this->loggedActivityCount($callback);
+
+        if ($expectedCount === null) {
+            PHPUnit::assertGreaterThan(
+                0,
+                $activityCount,
+                'No activities were logged that matched the specified criteria.',
+            );
+        } else {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $activityCount,
+                $activityCount
+                    .($activityCount === 1 ? ' activity was' : ' activities were')
+                    ." logged that matched the specified criteria, instead of {$expectedCount} expected.",
+            );
+        }
+    }
+
+    public function assertNothingLoggedMatching(Closure $callback): void
+    {
+        $this->assertLoggedMatching($callback, 0);
+    }
+
+    private function loggedActivityCount(Closure $callback): int
+    {
+        return count(
+            collect($this->loggedActivities)->filter($callback)
+        );
+    }
+}

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -38,6 +38,11 @@ class ActivityLogger
         $this->logStatus = $logStatus;
     }
 
+    public function fake()
+    {
+        app()->instance(self::class, resolve(ActivityLogFaker::class));
+    }
+
     public function setLogStatus(ActivityLogStatus $logStatus): static
     {
         $this->logStatus = $logStatus;
@@ -171,11 +176,16 @@ class ActivityLogger
             $this->tap([$activity->subject, 'tapActivity'], $activity->event ?? '');
         }
 
-        $activity->save();
+        $this->recordActivity($activity);
 
         $this->activity = null;
 
         return $activity;
+    }
+
+    public function recordActivity($activity)
+    {
+        $activity->save();
     }
 
     public function withoutLogs(Closure $callback): mixed

--- a/tests/ActivityLogFakerTest.php
+++ b/tests/ActivityLogFakerTest.php
@@ -1,0 +1,190 @@
+<?php
+
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Test\Models\User;
+use Spatie\Activitylog\Test\Models\Article;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+it('can fake logging activities if asked to', function () {
+    activity()->fake();
+
+    activity()->log('This will not be persisted to the database');
+
+    $this->assertCount(0, Activity::all());
+    $this->assertNull($this->getLastActivity());
+});
+
+it('can fake logging of model events if asked to', function () {
+    activity()->fake();
+
+    $this->article = new class() extends Article {
+        use LogsActivity;
+
+        public function getActivitylogOptions(): LogOptions
+        {
+            return LogOptions::defaults()
+            ->logOnly(['name', 'text']);
+        }
+    };
+
+    $this->createArticle();
+
+    $this->assertCount(0, Activity::all());
+    $this->assertNull($this->getLastActivity());
+});
+
+it('can test whether activities were logged', function () {
+    activity()->fake();
+
+    activity()->log('Something happened');
+    activity()->log('Something else happened');
+    activity()->log('Things keep happening!');
+
+    activity()->assertLogged();
+    activity()->assertLogged(3);
+});
+
+it('can test whether no activities were logged', function () {
+    activity()->fake();
+
+    activity()->assertNothingLogged();
+    activity()->assertLogged(0);
+});
+
+it('can test whether activities were logged to a particular log', function () {
+    activity()->fake();
+
+    activity('first log')->log('Something happened');
+    activity('second log')->log('Something else happened');
+    activity('second log')->log('Things keep happening!');
+
+    activity()->assertLoggedToLog('first log');
+    activity()->assertLoggedToLog('second log', 2);
+    activity()->assertNothingLoggedToLog('the mythical third log');
+});
+
+it('can test whether activities were logged with a particular description', function () {
+    activity()->fake();
+
+    activity()->log('Something happened');
+    activity()->log('Something happened');
+    activity()->log('Something else happened, but nobody was interested about it :(');
+
+    activity()->assertLoggedWithDescription('Something happened');
+    activity()->assertLoggedWithDescription('Something happened', 2);
+    activity()->assertNothingLoggedWithDescription('This thing did not happen at all');
+});
+
+it('can test whether activities were logged with a particular event', function () {
+    activity()->fake();
+
+    activity()->event('ThingEvent')->log('Something happened');
+    activity()->event('OtherThingEvent')->log('Something else happened');
+    activity()->event('OtherThingEvent')->log('Things keep happening!');
+
+    activity()->assertLoggedWithEvent('ThingEvent');
+    activity()->assertLoggedWithEvent('ThingEvent', 1);
+    activity()->assertLoggedWithEvent('OtherThingEvent', 2);
+    activity()->assertNothingLoggedWithEvent('DidNotHappenEvent');
+});
+
+it('can test whether activities were logged with a particular subject', function () {
+    activity()->fake();
+
+    $user = new User(['id' => 111]);
+    $otherUser = new User(['id' => 222]);
+
+    activity()->performedOn($user)->log('Something happened');
+    activity()->performedOn($user)->log('Something else happened');
+    activity()->performedOn($user)->log('Things keep happening to this poor user!');
+    activity()->performedOn($otherUser)->log('Something happened to this other user, but nobody cares :(');
+
+    activity()->assertLoggedWithSubjectType(User::class);
+    activity()->assertLoggedWithSubjectType(User::class, 4);
+    activity()->assertNothingLoggedWithSubjectType('NonUser');
+
+    activity()->assertLoggedWithSubjectId(111);
+    activity()->assertLoggedWithSubjectId(111, 3);
+    activity()->assertNothingLoggedWithSubjectId(333);
+});
+
+it('can test whether activities were logged with a particular causer', function () {
+    activity()->fake();
+
+    $user = new User(['id' => 111]);
+    $otherUser = new User(['id' => 222]);
+
+    activity()->causedBy($user)->log('Something happened');
+    activity()->causedBy($user)->log('Something else happened');
+    activity()->causedBy($user)->log('This user keeps making things happen!');
+    activity()->causedBy($otherUser)->log('This other user makes things happen too, but nobody cares :(');
+
+    activity()->assertLoggedWithCauserType(User::class);
+    activity()->assertLoggedWithCauserType(User::class, 4);
+    activity()->assertNothingLoggedWithCauserType('NonUser');
+
+    activity()->assertLoggedWithCauserId(111);
+    activity()->assertLoggedWithCauserId(111, 3);
+    activity()->assertNothingLoggedWithCauserId(333);
+});
+
+it('can test whether activities were logged with a particular set of properties', function () {
+    activity()->fake();
+
+    $properties = ['one' => 'une', 'two' => 'deux'];
+    $propertiesAndMore = ['one' => 'une', 'two' => 'deux', 'three' => 'trois'];
+    $differentProperties = ['one' => 'uno', 'two' => 'due'];
+    $unusedProperties = ['one' => 'uno', 'two' => 'dos'];
+
+    activity()->withProperties($properties)->log('Something happened');
+    activity()->withProperties($properties)->log('Something else happened');
+    activity()->withProperties($propertiesAndMore)->log('Things keep happening, sometimes with even more properties!');
+    activity()->withProperties($differentProperties)->log('This thing happened too, but nobody cares about it :(');
+
+    activity()->assertLoggedWithProperties($properties);
+    activity()->assertLoggedWithProperties($properties, 2);
+    activity()->assertNothingLoggedWithProperties($unusedProperties);
+});
+
+it('can test whether activities were logged that include particular properties', function () {
+    activity()->fake();
+
+    $properties = ['one' => 'une', 'two' => 'deux'];
+    $propertiesAndMore = ['one' => 'une', 'two' => 'deux', 'three' => 'trois'];
+    $differentProperties = ['one' => 'uno', 'two' => 'due'];
+    $unusedProperties = ['one' => 'uno', 'two' => 'dos'];
+
+    activity()->withProperties($properties)->log('Something happened');
+    activity()->withProperties($properties)->log('Something else happened');
+    activity()->withProperties($propertiesAndMore)->log('Things keep happening, sometimes with even more properties!');
+    activity()->withProperties($differentProperties)->log('This thing happened too, but nobody cares about it :(');
+
+    activity()->assertLoggedIncludingProperties($properties);
+    activity()->assertLoggedIncludingProperties($properties, 3);
+    activity()->assertNothingLoggedIncludingProperties($unusedProperties);
+});
+
+it('can test whether activities were logged based on a custom test', function () {
+    activity()->fake();
+
+    $properties = ['one' => 'une', 'two' => 'deux'];
+
+    activity()->withProperties($properties)->log('Something normal happened');
+    activity()->withProperties($properties)->log('Something else normal happened');
+    activity()->withProperties($properties)->log('Something weird happened, with those same properties');
+
+    $testOne = function ($activity) use ($properties) {
+        return
+            collect([$activity->properties])->contains('one', 'une')
+            && strpos($activity->description, 'normal') !== false;
+    };
+
+    $testTwo = function ($activity) {
+        return strpos($activity->description, 'Rumpelstiltskin') !== false;
+    };
+
+    activity()->assertLoggedMatching($testOne);
+    activity()->assertLoggedMatching($testOne, 2);
+    activity()->assertNothingLoggedMatching($testTwo);
+});


### PR DESCRIPTION
I make extensive use of this excellent package, but it's always bugged me slightly that I have to disable logging when running unit tests that are tailored to avoid hitting the database. 

This update would add a 'fake' feature to mock out the saving of log entries to the database, together with unit-testing assertions about what _would_ have been logged.