### PR TITLE
feat: add except record event

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -159,6 +159,12 @@ trait LogsActivity
             $events->push('restored');
         }
 
+        if (isset(static::$exceptRecordEvents)) {
+            $events = $events->filter(function (string $event) {
+                return !in_array($event, static::$exceptRecordEvents);
+            });
+        }
+
         return $events;
     }
 

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -58,6 +58,27 @@ it('can skip logging model events if asked to', function () {
     $this->assertNull($this->getLastActivity());
 });
 
+it('except created log event', function () {
+    $articleClass = new class() extends Article {
+        use LogsActivity;
+
+        protected $exceptRecordEvents = [
+            'created',
+        ];
+
+        public function getActivitylogOptions(): LogOptions
+        {
+            return LogOptions::defaults()->logOnly(['name']);
+        }
+    };
+    $article = new $articleClass();
+    $article->name = 'my name';
+    $article->save();
+
+    $this->assertCount(0, Activity::all());
+    $this->assertNull($this->getLastActivity());
+});
+
 it('can switch on activity logging after disabling it', function () {
     $article = new $this->article();
 


### PR DESCRIPTION
In addition to "[Customize the events to be logged](https://spatie.be/docs/laravel-activitylog/v4/advanced-usage/logging-model-events#content-customizing-the-events-being-logged)" another method to except events:

```php
class Article extends Model
{
    use LogsActivity;

    protected static $exceptRecordEvents = [
        'created',
    ];
```