### PR TITLE
Make 'event' column indexed

### DIFF
--- a/database/migrations/add_event_column_to_activity_log_table.php.stub
+++ b/database/migrations/add_event_column_to_activity_log_table.php.stub
@@ -9,7 +9,7 @@ class AddEventColumnToActivityLogTable extends Migration
     public function up()
     {
         Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table) {
-            $table->string('event')->nullable()->after('subject_type');
+            $table->string('event')->nullable()->index()->after('subject_type');
         });
     }
 


### PR DESCRIPTION
This PR sets the 'event' column to have an index, so performance is way better when searching millions of rows based on an event.