### PR TITLE
feat!: add laravel 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.2, 8.1, 8.0, 8.2]
-                laravel: ["^10.0", "^9.0", "^8.0"]
+                php: [8.3, 8.2, 8.1]
+                laravel: ["^11.0", "^10.0", "^9.0"]
                 dependency-version: [prefer-lowest, prefer-stable]
                 exclude:
-                    -   laravel: "^10.0"
-                        php: 8.0
-
+                    -   laravel: "^11.0"
+                        php: 8.1
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -31,16 +31,16 @@
     ],
     "homepage": "https://github.com/spatie/activitylog",
     "require": {
-        "php": "^8.0",
-        "illuminate/config": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/database": "^8.69 || ^9.27 || ^10.0",
-        "illuminate/support": "^8.0 || ^9.0 || ^10.0",
+        "php": "^8.1",
+        "illuminate/config": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/database": "^8.69 || ^9.27 || ^10.0 || ^11.0",
+        "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "spatie/laravel-package-tools": "^1.6.3"
     },
     "require-dev": {
         "ext-json": "*",
-        "orchestra/testbench": "^6.23 || ^7.0 || ^8.0",
-        "pestphp/pest": "^1.20"
+        "orchestra/testbench": "^6.23 || ^7.0 || ^8.0 || ^9.0",
+        "pestphp/pest": "^1.20 || ^2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -366,14 +366,13 @@ trait LogsActivity
             if ($model->hasCast($attribute)) {
                 $cast = $model->getCasts()[$attribute];
 
-                if (function_exists('enum_exists') && enum_exists($cast)) {
-                    if (method_exists($model, 'getStorableEnumValue')) {
+                if ($model->isEnumCastable($attribute)) {
+                    try {
                         $changes[$attribute] = $model->getStorableEnumValue($changes[$attribute]);
-                    } else {
-                        // ToDo: DEPRECATED - only here for Laravel 8 support
-                        $changes[$attribute] = $changes[$attribute] instanceof \BackedEnum
-                            ? $changes[$attribute]->value
-                            : $changes[$attribute]->name;
+                    } catch (\ArgumentCountError $e) {
+                        // In Laravel 11, this method has an extra argument
+                        // https://github.com/laravel/framework/pull/47465
+                        $changes[$attribute] = $model->getStorableEnumValue($cast, $changes[$attribute]);
                     }
                 }
 

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -28,6 +28,11 @@ class User extends Model implements Authenticatable
         return $this->attributes[$name];
     }
 
+    public function getAuthPasswordName()
+    {
+        return 'password';
+    }
+
     public function getAuthPassword()
     {
         return $this->attributes['password'];


### PR DESCRIPTION
This PR adds PHP 8.3 and Laravel 11 to testing matrix and updates illuminate dependencies.

BREAKING CHANGE: Drops support for PHP 8.0 and Laravel 8