### PR TITLE
Add causer- and subject-type scopes to Activity model

### DIFF
--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -108,11 +108,23 @@ class Activity extends Model implements ActivityContract
             ->where('causer_id', $causer->getKey());
     }
 
+    public function scopeCausedByType(Builder $query, string|Model $type): Builder
+    {
+        $type = is_string($type) ? $type : $type->getMorphClass();
+        return $query->where('causer_type', $type);
+    }
+
     public function scopeForSubject(Builder $query, Model $subject): Builder
     {
         return $query
             ->where('subject_type', $subject->getMorphClass())
             ->where('subject_id', $subject->getKey());
+    }
+
+    public function scopeForSubjectType(Builder $query, string|Model $type): Builder
+    {
+        $type = is_string($type) ? $type : $type->getMorphClass();
+        return $query->where('subject_type', $type);
     }
 
     public function scopeForEvent(Builder $query, string $event): Builder

--- a/tests/ActivityModelTest.php
+++ b/tests/ActivityModelTest.php
@@ -2,7 +2,9 @@
 
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Test\Models\Admin;
 use Spatie\Activitylog\Test\Models\Article;
+use Spatie\Activitylog\Test\Models\Post;
 use Spatie\Activitylog\Test\Models\User;
 
 beforeEach(function () {
@@ -55,6 +57,40 @@ it('provides a scope to get log items for a specific causer', function () {
     expect($activities->first()->description)->toEqual('Foo');
 });
 
+it('provides a scope to get log items for a specific causer class of given model', function () {
+    $subject = Article::first();
+    $causer = User::first();
+
+    activity()->on($subject)->by($causer)->log('Foo');
+    activity()->on($subject)->by(Admin::create([
+        'name' => 'An Admin User',
+    ]))->log('Bar');
+
+    $activities = Activity::causedByType($causer)->get();
+
+    expect($activities)->toHaveCount(1);
+    expect($activities->first()->causer_id)->toEqual($causer->getKey());
+    expect($activities->first()->causer_type)->toEqual(get_class($causer));
+    expect($activities->first()->description)->toEqual('Foo');
+});
+
+it('provides a scope to get log items for a specific causer class of given class name', function () {
+    $subject = Article::first();
+    $causer = User::first();
+
+    activity()->on($subject)->by($causer)->log('Foo');
+    activity()->on($subject)->by(Admin::create([
+        'name' => 'An Admin User',
+    ]))->log('Bar');
+
+    $activities = Activity::causedByType(User::class)->get();
+
+    expect($activities)->toHaveCount(1);
+    expect($activities->first()->causer_id)->toEqual($causer->getKey());
+    expect($activities->first()->causer_type)->toEqual(get_class($causer));
+    expect($activities->first()->description)->toEqual('Foo');
+});
+
 it('provides a scope to get log items for a specific event', function () {
     $subject = Article::first();
     activity()
@@ -76,6 +112,40 @@ it('provides a scope to get log items for a specific subject', function () {
     ]))->by($causer)->log('Bar');
 
     $activities = Activity::forSubject($subject)->get();
+
+    expect($activities)->toHaveCount(1);
+    expect($activities->first()->subject_id)->toEqual($subject->getKey());
+    expect($activities->first()->subject_type)->toEqual(get_class($subject));
+    expect($activities->first()->description)->toEqual('Foo');
+});
+
+it('provides a scope to get log items for a specific subject class of given model', function () {
+    $subject = Article::first();
+    $causer = User::first();
+
+    activity()->on($subject)->by($causer)->log('Foo');
+    activity()->on(Post::create([
+        'name' => 'A Post',
+    ]))->by($causer)->log('Bar');
+
+    $activities = Activity::forSubjectType($subject)->get();
+
+    expect($activities)->toHaveCount(1);
+    expect($activities->first()->subject_id)->toEqual($subject->getKey());
+    expect($activities->first()->subject_type)->toEqual(get_class($subject));
+    expect($activities->first()->description)->toEqual('Foo');
+});
+
+it('provides a scope to get log items for a specific subject class of given class name', function () {
+    $subject = Article::first();
+    $causer = User::first();
+
+    activity()->on($subject)->by($causer)->log('Foo');
+    activity()->on(Post::create([
+        'name' => 'A Post',
+    ]))->by($causer)->log('Bar');
+
+    $activities = Activity::forSubjectType(Article::class)->get();
 
     expect($activities)->toHaveCount(1);
     expect($activities->first()->subject_id)->toEqual($subject->getKey());

--- a/tests/Models/Admin.php
+++ b/tests/Models/Admin.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Traits\CausesActivity;
+
+class Admin extends User implements Authenticatable
+{
+    protected $table = 'admins';
+}

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models;
+
+class Post extends Article
+{
+    protected $table = 'posts';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,9 @@ use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Spatie\Activitylog\ActivitylogServiceProvider;
 use Spatie\Activitylog\Models\Activity;
+use Spatie\Activitylog\Test\Models\Admin;
 use Spatie\Activitylog\Test\Models\Article;
+use Spatie\Activitylog\Test\Models\Post;
 use Spatie\Activitylog\Test\Models\User;
 
 abstract class TestCase extends OrchestraTestCase
@@ -49,7 +51,7 @@ abstract class TestCase extends OrchestraTestCase
     {
         $this->migrateActivityLogTable();
 
-        $this->createTables('articles', 'users');
+        $this->createTables('articles', 'posts', 'users', 'admins');
         $this->seedModels(Article::class, User::class);
     }
 
@@ -81,6 +83,10 @@ abstract class TestCase extends OrchestraTestCase
                     $table->string('interval')->nullable();
                     $table->decimal('price')->nullable();
                     $table->string('status')->nullable();
+                }
+                if ($tableName === 'posts') {
+                    $table->integer('user_id')->unsigned()->nullable();
+                    $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
                 }
             });
         });


### PR DESCRIPTION
I added 2 scopes to the Activity model for convenience. You can use these scopes to fetch only the activity for subjects of a  certain class, or caused by a certain class.

```php
$user_activity = Activity::causedByType(User::class)->get();
$admin_activity = Activity::causedByType(Admin::class)->get();
```

or

```php
$activity_on_articles = Activity::forSubjectType(Article::class)->get();
$activity_on_posts = Activity::forSubjectType(Post::class)->get();
```