### PR TITLE
Option to disable retrieving fresh model

### DIFF
--- a/docs/api/log-options.md
+++ b/docs/api/log-options.md
@@ -44,6 +44,8 @@ public array $dontLogIfAttributesChangedOnly = [];
 
 public array $attributeRawValues = [];
 
+public bool $shouldRetrieveFresh = true;
+
 public ?Closure $descriptionForEvent = null;
 ```
 
@@ -183,4 +185,12 @@ public function useAttributeRawValues(array $attributes): LogOption;
  * Customize log description using callback
  */
 public function setDescriptionForEvent(Closure $callback): LogOption;
+```
+
+### shouldRetrieveFresh
+```php
+/**
+ * Do or do not retrieve model fresh from database (for events besides 'retrieved')
+ */
+public function shouldRetrieveFresh(bool $state = true): LogOption;
 ```

--- a/src/LogOptions.php
+++ b/src/LogOptions.php
@@ -26,6 +26,8 @@ class LogOptions
 
     public ?Closure $descriptionForEvent = null;
 
+    public bool $shouldRetrieveFresh = true;
+
     /**
      * Start configuring model with the default options.
      */
@@ -160,6 +162,16 @@ class LogOptions
     public function useAttributeRawValues(array $attributes): self
     {
         $this->attributeRawValues = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * Do or do not retrieve model fresh from database (for events besides 'retrieved')
+     */
+    public function shouldRetrieveFresh(bool $state = true): self
+    {
+        $this->shouldRetrieveFresh = $state;
 
         return $this;
     }

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -265,17 +265,13 @@ trait LogsActivity
         }
 
         $properties['attributes'] = static::logChanges(
-
-            // if the current event is retrieved, get the model itself
-            // else get the fresh default properties from database
-            // as wouldn't be part of the saved model instance.
-            $processingEvent == 'retrieved'
-                ? $this
-                : (
+            $this->shouldRetrieveFreshForLog($processingEvent)
+                ? (
                     $this->exists
                         ? $this->fresh() ?? $this
                         : $this
                 )
+                : $this
         );
 
         if (static::eventsToBeRecorded()->contains('updated') && $processingEvent == 'updated') {
@@ -325,6 +321,21 @@ trait LogsActivity
         }
 
         return $properties;
+    }
+
+    /**
+     * Whether to retrieve the model fresh from database for logging
+     */
+    public function shouldRetrieveFreshForLog(string $processingEvent): bool
+    {
+        if ($processingEvent == 'retrieved') {
+            // if the current event is retrieved, get the model itself
+            // else get the fresh default properties from database
+            // as wouldn't be part of the saved model instance.
+            return false;
+        }
+
+        return $this->activitylogOptions->shouldRetrieveFresh;
     }
 
     public static function logChanges(Model $model): array


### PR DESCRIPTION
I have added an option to the `LogOptions` in order to disable retrieving a fresh copy of the model. The default behavior is unchanged.

This can be useful if database permissions are limited. For example, when a public facing website is allowed to `insert` but not `select` from a privacy-sensitive table.

Let me know if you prefer a different synthax; happy to make improvements