### PR TITLE
Bug Fixed EventLogBag modification pipe's interaction with different models

### DIFF
--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -89,6 +89,9 @@ trait LogsActivity
 
                 // Reset log options so the model can be serialized.
                 $model->activitylogOptions = null;
+
+                // Clear pipelines for each event to avoid interact other model events;
+                static::$changesPipes = [];
             });
         });
     }


### PR DESCRIPTION
As `LogsActivity::$changesPipes` is `static`, this stays in memory and interacts with other model's events. 

**Scenario :**
I used the below function to add more `LoggablePipe` to modify my `EventLogBag`, but this was keeping the `LoggablePipe`s into the memory and those `LoggablePipe`s were modifying the other model's event `EventLogBag`s.

```php
    public static function addLogChange(LoggablePipe $pipe): void
    {
        static::$changesPipes[] = $pipe;
    }
```

So, I've cleared the `LoggablePipe`s after each log write. Simply added 
```php
    protected static function bootLogsActivity(): void
    {
        ....
        ....
            // Clear pipelines for each event to avoid interact other model events;
            static::$changesPipes = [];
        ....
        ....
    }

```

as it has by default, that fixed my issue. 