### PR TITLE
Add Compareable interface to change comparison logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 .phpunit.result.cache
 .php_cs.cache
 .phpunit.cache
+.idea

--- a/docs/advanced-usage/altering-comparison-behavior.md
+++ b/docs/advanced-usage/altering-comparison-behavior.md
@@ -1,0 +1,35 @@
+---
+title: Altering comparison behavior
+weight: 7
+---
+
+By default, the spaceship operator is used to compare 2 objects with each other.
+This does not always result in what we expect.
+
+For instance, when using the `laravel-model-states` package, a copy of the model is stored per instance of the state.
+Causing the state to be logged as a change even when they appear the same.
+
+We can adjust the way objects are being compared by implementing the `Compareable` interface.
+This will provide us with a `compareTo` function that can tweak the comparison logic.
+
+```php
+use Spatie\Activitylog\Contracts\Compareable;
+
+abstract class OrderState extends State implements Compareable
+{
+    public function compareTo(Compareable $compareable): int
+    {
+        if (! $compareable instanceof State) {
+            return 1;
+        }
+
+        if (get_class($this) !== get_class($compareable)) {
+            return 1;
+        };
+        
+        return 0;
+    }
+}
+```
+
+This way no changes are being logged when you decide 2 objects are equal to each other.

--- a/src/Contracts/Compareable.php
+++ b/src/Contracts/Compareable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\Activitylog\Contracts;
+
+interface Compareable
+{
+    public function compareTo(Compareable $compareable): int;
+}

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 use Spatie\Activitylog\ActivityLogger;
 use Spatie\Activitylog\ActivitylogServiceProvider;
 use Spatie\Activitylog\ActivityLogStatus;
+use Spatie\Activitylog\Contracts\Compareable;
 use Spatie\Activitylog\Contracts\LoggablePipe;
 use Spatie\Activitylog\EventLogBag;
 use Spatie\Activitylog\LogOptions;
@@ -310,6 +311,12 @@ trait LogsActivity
                         return CarbonInterval::make($new)->equalTo($old) ? 0 : 1;
                     }
 
+                    if ($old instanceof Compareable){
+                        return $old->compareTo($new);
+                    } elseif ($new instanceof Compareable){
+                        return $new->compareTo($old);
+                    }
+
                     return $new <=> $old;
                 }
             );
@@ -365,6 +372,7 @@ trait LogsActivity
 
             if ($model->hasCast($attribute)) {
                 $cast = $model->getCasts()[$attribute];
+                ray($cast);
 
                 if ($model->isEnumCastable($attribute)) {
                     try {

--- a/src/Traits/LogsActivity.php
+++ b/src/Traits/LogsActivity.php
@@ -372,7 +372,6 @@ trait LogsActivity
 
             if ($model->hasCast($attribute)) {
                 $cast = $model->getCasts()[$attribute];
-                ray($cast);
 
                 if ($model->isEnumCastable($attribute)) {
                     try {

--- a/tests/Casts/StateCasts.php
+++ b/tests/Casts/StateCasts.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Test\Models\States\Pending;
+use Spatie\Activitylog\Test\Models\States\PendingCompareable;
+use Spatie\Activitylog\Test\Models\States\Ready;
+use Spatie\Activitylog\Test\Models\States\ReadyCompareable;
+
+class StateCasts implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes)
+    {
+        return match ($value) {
+            'ready' => new Ready(),
+            'pending' => new Pending(),
+            'ready_compareable' => new ReadyCompareable(),
+            'pending_compareable' => new PendingCompareable(),
+        };
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes)
+    {
+        return $value->status_name;
+    }
+}

--- a/tests/Models/States/Pending.php
+++ b/tests/Models/States/Pending.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models\States;
+
+class Pending extends State
+{
+    public function __construct()
+    {
+        $this->status_name = 'pending';
+    }
+}

--- a/tests/Models/States/PendingCompareable.php
+++ b/tests/Models/States/PendingCompareable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models\States;
+
+use Spatie\Activitylog\Contracts\Compareable;
+
+class PendingCompareable extends State implements Compareable
+{
+    public function __construct()
+    {
+        $this->status_name = 'pending_compareable';
+    }
+
+    public function compareTo(Compareable $compareable): int
+    {
+        return $this->other_field === $compareable->other_field ? 0 : 1;
+    }
+}

--- a/tests/Models/States/Ready.php
+++ b/tests/Models/States/Ready.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models\States;
+
+class Ready extends State
+{
+    public function __construct()
+    {
+        $this->status_name = 'ready';
+    }
+}

--- a/tests/Models/States/ReadyCompareable.php
+++ b/tests/Models/States/ReadyCompareable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models\States;
+
+use Spatie\Activitylog\Contracts\Compareable;
+
+class ReadyCompareable extends State implements Compareable
+{
+    public function __construct()
+    {
+        $this->status_name = 'ready_compareable';
+    }
+
+    public function compareTo(Compareable $compareable): int
+    {
+        return $this->other_field === $compareable->other_field ? 0 : 1;
+    }
+}

--- a/tests/Models/States/State.php
+++ b/tests/Models/States/State.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Activitylog\Test\Models\States;
+
+use Spatie\Activitylog\Test\Casts\StateCasts;
+
+class State extends StateCasts
+{
+    public string $status_name;
+    public string $other_field = 'other value';
+
+    public function __toString(): string
+    {
+        return $this->status_name;
+    }
+}


### PR DESCRIPTION
By default, the spaceship operator is used to compare 2 objects with each other.
This does not always result in what we expect.

We can adjust the way objects are being compared by implementing the `Compareable` interface.
This will provide us with a `compareTo` function that can tweak the comparison logic.