### PR TITLE
Enhance efficiency of fetching latest activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ activity()
    ->withProperties(['customProperty' => 'customValue'])
    ->log('Look, I logged something');
 
-$lastLoggedActivity = Activity::all()->last();
+$lastLoggedActivity = Activity::latest()->first();
 
 $lastLoggedActivity->subject; //returns an instance of an eloquent model
 $lastLoggedActivity->causer; //returns an instance of your user model
@@ -46,7 +46,7 @@ $newsItem->name = 'updated name';
 $newsItem->save();
 
 //updating the newsItem will cause the logging of an activity
-$activity = Activity::all()->last();
+$activity = Activity::latest()->first();
 
 $activity->description; //returns 'updated'
 $activity->subject; //returns the instance of NewsItem that was saved

--- a/docs/advanced-usage/define-causer-for-runtime.md
+++ b/docs/advanced-usage/define-causer-for-runtime.md
@@ -19,8 +19,8 @@ CauserResolver::setCauser($causer);
 
 $product->update(['name' => 'New name']);
 
-Activity::all()->last()->causer; // Product Model
-Activity::all()->last()->causer->id; // Product#1 Owner
+Activity::latest()->first()->causer; // Product Model
+Activity::latest()->first()->causer->id; // Product#1 Owner
 
 ```
 

--- a/docs/advanced-usage/logging-model-events.md
+++ b/docs/advanced-usage/logging-model-events.md
@@ -54,7 +54,7 @@ $newsItem = NewsItem::create([
 ]);
 
 //creating the newsItem will cause an activity being logged
-$activity = Activity::all()->last();
+$activity = Activity::latest()->first();
 
 $activity->description; //returns 'created'
 $activity->subject; //returns the instance of NewsItem that was created
@@ -68,7 +68,7 @@ $newsItem->name = 'updated name';
 $newsItem->save();
 
 //updating the newsItem will cause an activity being logged
-$activity = Activity::all()->last();
+$activity = Activity::latest()->first();
 
 $activity->description; //returns 'updated'
 $activity->subject; //returns the instance of NewsItem that was created
@@ -97,7 +97,7 @@ Now, what happens when you call delete?
 $newsItem->delete();
 
 //deleting the newsItem will cause an activity being logged
-$activity = Activity::all()->last();
+$activity = Activity::latest()->first();
 
 $activity->description; //returns 'deleted'
 $activity->changes; //returns ['attributes' => ['name' => 'updated name', 'text' => 'Lorum']];
@@ -153,7 +153,7 @@ $newsItem = NewsItem::create([
 ]);
 
 //creating the newsItem will cause an activity being logged
-$activity = Activity::all()->last();
+$activity = Activity::latest()->first();
 
 $activity->description; //returns 'This model has been created'
 ```

--- a/docs/advanced-usage/manipulate-changes-array.md
+++ b/docs/advanced-usage/manipulate-changes-array.md
@@ -32,7 +32,7 @@ NewsItem::addLogChange(new RemoveKeyFromLogChangesPipe('name'));
 $article = NewsItem::create(['name' => 'new article', 'text' => 'new article text']);
 $article->update(['name' => 'update article', 'text' => 'update article text']);
 
-Activity::all()->last()->changes();
+Activity::latest()->first()->changes();
 /*
     'attributes' => [
         'text' => 'updated text',

--- a/docs/advanced-usage/using-multiple-logs.md
+++ b/docs/advanced-usage/using-multiple-logs.md
@@ -10,7 +10,7 @@ Without specifying a log name the activities will be logged on the default log.
 ```php
 activity()->log('hi');
 
-$lastActivity = Spatie\Activitylog\Models\Activity::all()->last();
+$lastActivity = Spatie\Activitylog\Models\Activity::latest()->first();
 
 $lastActivity->log_name; //returns 'default';
 ```
@@ -24,7 +24,7 @@ You can specify the log on which an activity must be logged by passing the log n
 ```php
 activity('other-log')->log("hi");
 
-Activity::all()->last()->log_name; //returns 'other-log';
+Activity::latest()->first()->log_name; //returns 'other-log';
 ```
 
 ## Specifying a log for each model

--- a/docs/advanced-usage/using-placeholders.md
+++ b/docs/advanced-usage/using-placeholders.md
@@ -14,6 +14,6 @@ activity()
     ->withProperties(['laravel' => 'awesome'])
     ->log('The subject name is :subject.name, the causer name is :causer.name and Laravel is :properties.laravel');
 
-$lastActivity = Activity::all()->last();
+$lastActivity = Activity::latest()->first();
 $lastActivity->description; //returns 'The subject name is article name, the causer name is user name and Laravel is awesome';
 ```

--- a/docs/basic-usage/logging-activity.md
+++ b/docs/basic-usage/logging-activity.md
@@ -14,7 +14,7 @@ activity()->log('Look mum, I logged something');
 You can retrieve the activity using the `Spatie\Activitylog\Models\Activity` model.
 
 ```php
-$lastActivity = Activity::all()->last(); //returns the last logged activity
+$lastActivity = Activity::latest()->first(); //returns the last logged activity
 
 $lastActivity->description; //returns 'Look mum, I logged something';
 ```
@@ -28,7 +28,7 @@ activity()
    ->performedOn($someContentModel)
    ->log('edited');
 
-$lastActivity = Activity::all()->last(); //returns the last logged activity
+$lastActivity = Activity::latest()->first(); //returns the last logged activity
 
 $lastActivity->subject; //returns the model that was passed to `performedOn`;
 ```
@@ -45,7 +45,7 @@ activity()
    ->performedOn($someContentModel)
    ->log('edited');
 
-$lastActivity = Activity::all()->last(); //returns the last logged activity
+$lastActivity = Activity::latest()->first(); //returns the last logged activity
 
 $lastActivity->causer; //returns the model that was passed to `causedBy`;
 ```
@@ -67,7 +67,7 @@ activity()
    ->withProperties(['key' => 'value'])
    ->log('edited');
 
-$lastActivity = Activity::all()->last(); //returns the last logged activity
+$lastActivity = Activity::latest()->first(); //returns the last logged activity
 
 $lastActivity->getExtraProperty('key'); //returns 'value'
 
@@ -113,7 +113,7 @@ activity()
    })
    ->log('edited');
 
-$lastActivity = Activity::all()->last();
+$lastActivity = Activity::latest()->first();
 
 $lastActivity->my_custom_field; // returns 'my special value'
 ```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,7 +26,7 @@ activity()
    ->withProperties(['customProperty' => 'customValue'])
    ->log('Look mum, I logged something');
 
-$lastLoggedActivity = Activity::all()->last();
+$lastLoggedActivity = Activity::latest()->first();
 
 $lastLoggedActivity->subject; //returns an instance of an eloquent model
 $lastLoggedActivity->causer; //returns an instance of your user model
@@ -41,7 +41,7 @@ $newsItem->name = 'updated name';
 $newsItem->save();
 
 //updating the newsItem will cause an activity being logged
-$activity = Activity::all()->last();
+$activity = Activity::latest()->first();
 
 $activity->description; //returns 'updated'
 $activity->subject; //returns the instance of NewsItem that was created

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -97,7 +97,7 @@ abstract class TestCase extends OrchestraTestCase
 
     public function getLastActivity(): ?Activity
     {
-        return Activity::all()->last();
+        return Activity::latest()->first();
     }
 
     public function markTestAsPassed(): void


### PR DESCRIPTION
Instead of fetching all activities from database, and then get the last one, it is better to only fetch the latest.
This is mainly an update of the docs, but also a single test.