### PR TITLE
[FIX]: Handle string values for activity log-enabled configuration. 

### DIFF
--- a/src/ActivityLogStatus.php
+++ b/src/ActivityLogStatus.php
@@ -10,7 +10,9 @@ class ActivityLogStatus
 
     public function __construct(Repository $config)
     {
-        $this->enabled = $config['activitylog.enabled'];
+        $this->enabled = $config['activitylog.enabled'] !== null ?
+            (bool) $config['activitylog.enabled'] :
+            null;
     }
 
     public function enable(): bool

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -46,6 +46,38 @@ it('will log an activity when enabled option is null', function () {
     expect($this->getLastActivity()->description)->toEqual($this->activityDescription);
 });
 
+it('will not log an activity when enabled option is zero', function () {
+    config(['activitylog.enabled' => 0]);
+
+    activity()->log($this->activityDescription);
+
+    expect($this->getLastActivity())->toBeNull();
+});
+
+it('will not log an activity when enabled option is zero in string', function () {
+    config(['activitylog.enabled' => '0']);
+
+    activity()->log($this->activityDescription);
+
+    expect($this->getLastActivity())->toBeNull();
+});
+
+it('will log an activity when enabled option is one', function () {
+    config(['activitylog.enabled' => 1]);
+
+    activity()->log($this->activityDescription);
+
+    expect($this->getLastActivity()->description)->toEqual($this->activityDescription);
+});
+
+it('will log an activity when enabled option is one in string', function () {
+    config(['activitylog.enabled' => '1']);
+
+    activity()->log($this->activityDescription);
+
+    expect($this->getLastActivity()->description)->toEqual($this->activityDescription);
+});
+
 it('will log to the default log by default', function () {
     activity()->log($this->activityDescription);
 


### PR DESCRIPTION
**Use Case:** 

I want to disable the activity log during the test. We are setting up default env variables using the `phpunit.xml` file as mentioned below. 

```
<env name="ACTIVITY_LOGGER_ENABLED" value="false"/>
```

**Root Cause:** 
But, as per check on [ActivityLogStatus.php](https://github.com/spatie/laravel-activitylog/blob/93288ac6b69e28a604be5bb9be0192b808c58610/src/ActivityLogStatus.php#L28) making a strict comparison.

**Solution:**
I have added support for the string values for the enabled option. And, covered all the tests for this feature. Please feel free to let me know if you have any concerns.

Thanks