### PR TITLE
Use plural table name `activity_logs` instead of `activity_log`

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -41,7 +41,7 @@ return [
      * This is the name of the table that will be created by the migration and
      * used by the Activity model shipped with this package.
      */
-    'table_name' => 'activity_log',
+    'table_name' => 'activity_logs',
 
     /*
      * This is the database connection that will be used by the migration and


### PR DESCRIPTION
This PR changes the default table name to be pluralized to fall in line with Laravel's pluralized table name convention.

I know it has been `activity_log` for some time, but am not really sure why, unless I'm missing something? Let me know if so! 👍 