### PR TITLE
fix: php 8.4 deprecation warnings

### DIFF
--- a/docs/advanced-usage/batch-logs.md
+++ b/docs/advanced-usage/batch-logs.md
@@ -127,7 +127,7 @@ Activity::forBatch($uuid)->get(); // all the activity that happend in the batch
 ```php
 class SomeJob
 {
-    public function handle(string $value, string $batchUuid = null)
+    public function handle(string $value, ?string $batchUuid = null)
     {
         LogBatch::startBatch();
         if($batchUuid) LogBatch::setBatch($batchUuid);

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -133,7 +133,7 @@ class ActivityLogger
         return $this->useLog($logName);
     }
 
-    public function tap(callable $callback, string $eventName = null): static
+    public function tap(callable $callback, ?string $eventName = null): static
     {
         call_user_func($callback, $this->getActivity(), $eventName);
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,7 +4,7 @@ use Spatie\Activitylog\ActivityLogger;
 use Spatie\Activitylog\ActivityLogStatus;
 
 if (! function_exists('activity')) {
-    function activity(string $logName = null): ActivityLogger
+    function activity(?string $logName = null): ActivityLogger
     {
         $defaultLogName = config('activitylog.default_log_name');
 


### PR DESCRIPTION
I noticed this deprecation warning when using the package with PHP 8.4

> Deprecated: activity(): Implicitly marking parameter $logName as nullable is deprecated, the explicit nullable type must be used instead

I have updated all places I can see where the implicit nullable declaration was used. This includes an example in the documentation.