### PR TITLE
Activity Facade

### DIFF
--- a/src/Facades/Activity.php
+++ b/src/Facades/Activity.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\Activitylog\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Spatie\Activitylog\PendingActivityLog;
+
+/**
+ * @method static \Spatie\Activitylog\ActivityLogger setLogStatus(\Spatie\Activitylog\ActivityLogStatus $logStatus)
+ * @method static \Spatie\Activitylog\ActivityLogger performedOn(\Illuminate\Database\Eloquent\Model $model)
+ * @method static \Spatie\Activitylog\ActivityLogger on(\Illuminate\Database\Eloquent\Model $model)
+ * @method static \Spatie\Activitylog\ActivityLogger causedBy(\Illuminate\Database\Eloquent\Model|string|int|null $modelOrId)
+ * @method static \Spatie\Activitylog\ActivityLogger by(\Illuminate\Database\Eloquent\Model|string|int|null $modelOrId)
+ * @method static \Spatie\Activitylog\ActivityLogger causedByAnonymous()
+ * @method static \Spatie\Activitylog\ActivityLogger byAnonymous()
+ * @method static \Spatie\Activitylog\ActivityLogger event(string $event)
+ * @method static \Spatie\Activitylog\ActivityLogger setEvent(string $event)
+ * @method static \Spatie\Activitylog\ActivityLogger withProperties(mixed $properties)
+ * @method static \Spatie\Activitylog\ActivityLogger withProperty(string $key, mixed $value)
+ * @method static \Spatie\Activitylog\ActivityLogger createdAt(\DateTimeInterface $dateTime)
+ * @method static \Spatie\Activitylog\ActivityLogger useLog(string|null $logName)
+ * @method static \Spatie\Activitylog\ActivityLogger inLog(string|null $logName)
+ * @method static \Spatie\Activitylog\ActivityLogger tap(callable $callback, string|null $eventName = null)
+ * @method static \Spatie\Activitylog\ActivityLogger enableLogging()
+ * @method static \Spatie\Activitylog\ActivityLogger disableLogging()
+ * @method static \Spatie\Activitylog\Contracts\Activity|null log(string $description)
+ * @method static mixed withoutLogs(\Closure $callback)
+ * @method static \Spatie\Activitylog\ActivityLogger|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
+ * @method static \Spatie\Activitylog\ActivityLogger|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
+ * @method static void macro(string $name, object|callable $macro)
+ * @method static void mixin(object $mixin, bool $replace = true)
+ * @method static bool hasMacro(string $name)
+ * @method static void flushMacros()
+ *
+ * @see \Spatie\Activitylog\PendingActivityLog
+ */
+class Activity extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return PendingActivityLog::class;
+    }
+}

--- a/src/PendingActivityLog.php
+++ b/src/PendingActivityLog.php
@@ -11,14 +11,8 @@ class PendingActivityLog
 {
     use ForwardsCalls;
 
-    /**
-     * The activity logger instance.
-     */
     protected ActivityLogger $logger;
 
-    /**
-     * Constructor.
-     */
     public function __construct(ActivityLogger $logger, ActivityLogStatus $status)
     {
         $this->logger = $logger
@@ -26,17 +20,11 @@ class PendingActivityLog
             ->useLog(config('activitylog.default_log_name'));
     }
 
-    /**
-     * Get the activity logger instance.
-     */
     public function logger(): ActivityLogger
     {
         return $this->logger;
     }
-
-    /**
-     * Forward calls to the logger instance.
-     */
+    
     public function __call(string $method, array $parameters): mixed
     {
         return $this->forwardCallTo($this->logger, $method, $parameters);

--- a/src/PendingActivityLog.php
+++ b/src/PendingActivityLog.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\Activitylog;
+
+use Illuminate\Support\Traits\ForwardsCalls;
+
+/**
+ * @mixin \Spatie\Activitylog\ActivityLogger
+ */
+class PendingActivityLog
+{
+    use ForwardsCalls;
+
+    /**
+     * The activity logger instance.
+     */
+    protected ActivityLogger $logger;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(ActivityLogger $logger, ActivityLogStatus $status)
+    {
+        $this->logger = $logger
+            ->setLogStatus($status)
+            ->useLog(config('activitylog.default_log_name'));
+    }
+
+    /**
+     * Get the activity logger instance.
+     */
+    public function logger(): ActivityLogger
+    {
+        return $this->logger;
+    }
+
+    /**
+     * Forward calls to the logger instance.
+     */
+    public function __call(string $method, array $parameters): mixed
+    {
+        return $this->forwardCallTo($this->logger, $method, $parameters);
+    }
+}

--- a/src/PendingActivityLog.php
+++ b/src/PendingActivityLog.php
@@ -24,7 +24,7 @@ class PendingActivityLog
     {
         return $this->logger;
     }
-    
+
     public function __call(string $method, array $parameters): mixed
     {
         return $this->forwardCallTo($this->logger, $method, $parameters);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,17 +1,18 @@
 <?php
 
 use Spatie\Activitylog\ActivityLogger;
-use Spatie\Activitylog\ActivityLogStatus;
+use Spatie\Activitylog\PendingActivityLog;
 
 if (! function_exists('activity')) {
     function activity(?string $logName = null): ActivityLogger
     {
-        $defaultLogName = config('activitylog.default_log_name');
+        /** @var PendingActivityLog $log */
+        $log = app(PendingActivityLog::class);
 
-        $logStatus = app(ActivityLogStatus::class);
+        if ($logName) {
+            $log->useLog($logName);
+        }
 
-        return app(ActivityLogger::class)
-            ->useLog($logName ?? $defaultLogName)
-            ->setLogStatus($logStatus);
+        return $log->logger();
     }
 }

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -4,6 +4,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Support\Collection;
 use Spatie\Activitylog\Exceptions\CouldNotLogActivity;
+use Spatie\Activitylog\Facades\Activity as ActivityFacade;
 use Spatie\Activitylog\Facades\CauserResolver;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Models\Activity;
@@ -18,6 +19,12 @@ beforeEach(function () {
 
 it('can log an activity', function () {
     activity()->log($this->activityDescription);
+
+    expect($this->getLastActivity()->description)->toEqual($this->activityDescription);
+});
+
+it('can log an activity with facade', function () {
+    ActivityFacade::log($this->activityDescription);
 
     expect($this->getLastActivity()->description)->toEqual($this->activityDescription);
 });


### PR DESCRIPTION
### Description

This PR adds a new `Activity` facade for those who prefer it to global helpers.

There's existing facades for other utilities in this library already so it feels out of place that there isn't one already for creating an actual activity.

### Usage

All the typical methods can be used as you'd expect:

```php
use Spatie\Activitylog\Facades\Activity;

Activity::on($team)
   ->causedBy($user)
   ->event('sent-invitation')
   ->withProperties(['email' => 'foo@bar.com'])
   ->log('User sent an invitation to an email address.');
```

Let me know your thoughts!