### PR TITLE
Add BackedEnum Support to Activity::log()

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -11,8 +11,8 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use Spatie\Activitylog\Contracts\Activity as ActivityContract;
-use TypeError;
 
 class ActivityLogger
 {
@@ -59,7 +59,7 @@ class ActivityLogger
         return $this->performedOn($model);
     }
 
-    public function causedBy(Model | int | string | null $modelOrId): static
+    public function causedBy(Model|int|string|null $modelOrId): static
     {
         if ($modelOrId === null) {
             return $this;
@@ -72,7 +72,7 @@ class ActivityLogger
         return $this;
     }
 
-    public function by(Model | int | string | null $modelOrId): static
+    public function by(Model|int|string|null $modelOrId): static
     {
         return $this->causedBy($modelOrId);
     }
@@ -156,7 +156,7 @@ class ActivityLogger
         return $this;
     }
 
-    public function log(BackedEnum | string $description): ?ActivityContract
+    public function log(BackedEnum|string $description): ?ActivityContract
     {
         if ($this->logStatus->disabled()) {
             return null;
@@ -164,7 +164,7 @@ class ActivityLogger
 
         if ($description instanceof BackedEnum) {
             if (!is_string($description->value)) {
-                throw new TypeError('Description must be of type string or StringBackedEnum');
+                throw new InvalidArgumentException('Description must be of type string or StringBackedEnum');
             }
 
             $description = $description->value;
@@ -210,7 +210,7 @@ class ActivityLogger
 
             $attribute = Str::before(Str::after($match, ':'), '.');
 
-            if (! in_array($attribute, ['subject', 'causer', 'properties'])) {
+            if (!in_array($attribute, ['subject', 'causer', 'properties'])) {
                 return $match;
             }
 
@@ -228,7 +228,7 @@ class ActivityLogger
 
     protected function getActivity(): ActivityContract
     {
-        if (! $this->activity instanceof ActivityContract) {
+        if (!$this->activity instanceof ActivityContract) {
             $this->activity = ActivitylogServiceProvider::getActivityModelInstance();
             $this
                 ->useLog($this->defaultLogName)

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Activitylog;
 
+use BackedEnum;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Config\Repository;
@@ -154,10 +155,14 @@ class ActivityLogger
         return $this;
     }
 
-    public function log(string $description): ?ActivityContract
+    public function log(BackedEnum | string $description): ?ActivityContract
     {
         if ($this->logStatus->disabled()) {
             return null;
+        }
+
+        if ($description instanceof BackedEnum) {
+            $description = $description->value;
         }
 
         $activity = $this->activity;

--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Spatie\Activitylog\Contracts\Activity as ActivityContract;
+use TypeError;
 
 class ActivityLogger
 {
@@ -162,6 +163,10 @@ class ActivityLogger
         }
 
         if ($description instanceof BackedEnum) {
+            if (!is_string($description->value)) {
+                throw new TypeError('Description must be of type string or StringBackedEnum');
+            }
+
             $description = $description->value;
         }
 

--- a/src/Facades/Activity.php
+++ b/src/Facades/Activity.php
@@ -23,7 +23,7 @@ use Spatie\Activitylog\PendingActivityLog;
  * @method static \Spatie\Activitylog\ActivityLogger tap(callable $callback, string|null $eventName = null)
  * @method static \Spatie\Activitylog\ActivityLogger enableLogging()
  * @method static \Spatie\Activitylog\ActivityLogger disableLogging()
- * @method static \Spatie\Activitylog\Contracts\Activity|null log(string $description)
+ * @method static \Spatie\Activitylog\Contracts\Activity|null log(\BackedEnum | string $description)
  * @method static mixed withoutLogs(\Closure $callback)
  * @method static \Spatie\Activitylog\ActivityLogger|mixed when(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)
  * @method static \Spatie\Activitylog\ActivityLogger|mixed unless(\Closure|mixed|null $value = null, callable|null $callback = null, callable|null $default = null)

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -450,6 +450,20 @@ it('logs backed enums in properties', function () {
     $this->assertSame('published', $this->getLastActivity()->properties['string_backed_enum']);
 })->skip(version_compare(PHP_VERSION, '8.1', '<'), "PHP < 8.1 doesn't support enum");
 
+it('logs backed enums in log description', function () {
+    activity()
+        ->log(\Spatie\Activitylog\Test\Enums\StringBackedEnum::Published);
+
+    $this->assertSame('published', $this->getLastActivity()->description);
+})->skip(version_compare(PHP_VERSION, '8.1', '<'), "PHP < 8.1 doesn't support enum");
+
+it('throws a type error when int backed enum is supplied to log', function () {
+    activity()
+        ->log(\Spatie\Activitylog\Test\Enums\IntBackedEnum::Published);
+})
+    ->throws(TypeError::class)
+    ->skip(version_compare(PHP_VERSION, '8.1', '<'), "PHP < 8.1 doesn't support enum");
+
 it('does not log non backed enums in properties', function () {
     activity()
         ->withProperty('non_backed_enum', NonBackedEnum::Published)

--- a/tests/ActivityLoggerTest.php
+++ b/tests/ActivityLoggerTest.php
@@ -115,7 +115,7 @@ it('can log an activity with a causer that has been set from other context', fun
     $article = Article::first();
 
     activity()
-           ->log($this->activityDescription);
+        ->log($this->activityDescription);
 
     $firstActivity = Activity::first();
 
@@ -291,8 +291,7 @@ it('will not replace non placeholders', function () {
 });
 
 it('returns an instance of the activity log after logging when using a custom model', function () {
-    $activityClass = new class() extends Activity {
-    };
+    $activityClass = new class() extends Activity {};
 
     $activityClassName = get_class($activityClass);
 
@@ -461,7 +460,7 @@ it('throws a type error when int backed enum is supplied to log', function () {
     activity()
         ->log(\Spatie\Activitylog\Test\Enums\IntBackedEnum::Published);
 })
-    ->throws(TypeError::class)
+    ->throws(InvalidArgumentException::class)
     ->skip(version_compare(PHP_VERSION, '8.1', '<'), "PHP < 8.1 doesn't support enum");
 
 it('does not log non backed enums in properties', function () {


### PR DESCRIPTION
This PR adds `BackedEnum` support to Activity::log(). I find this useful because I use this package in my billing system, where I log why a tenant's status has changed during automated processes. Most of these messages are identical strings, so I thought it would make sense to add support for `BackedEnum`s.

If there are any changes or improvements you would like me to make, please let me know. 🤓