### PR TITLE
Unify `activity` property access on `ActivityLogger`

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -77,8 +77,10 @@ class ActivityLogger
 
     public function causedByAnonymous(): static
     {
-        $this->activity->causer_id = null;
-        $this->activity->causer_type = null;
+        $activity = $this->getActivity();
+
+        $activity->causer_id = null;
+        $activity->causer_type = null;
 
         return $this;
     }
@@ -95,7 +97,7 @@ class ActivityLogger
 
     public function setEvent(string $event): static
     {
-        $this->activity->event = $event;
+        $this->getActivity()->event = $event;
 
         return $this;
     }
@@ -160,7 +162,7 @@ class ActivityLogger
             return null;
         }
 
-        $activity = $this->activity;
+        $activity = $this->getActivity();
 
         $activity->description = $this->replacePlaceholders(
             $activity->description ?? $description,
@@ -220,6 +222,7 @@ class ActivityLogger
     {
         if (! $this->activity instanceof ActivityContract) {
             $this->activity = ActivitylogServiceProvider::getActivityModelInstance();
+
             $this
                 ->useLog($this->defaultLogName)
                 ->withProperties([])


### PR DESCRIPTION
This PR unifies using the `getActivity()` method to ensure an `Activity` instance is always retrieved, no matter which methods are called first.

Previously, creating this class manually and calling `setEvent(...)` or `causedByAnonymous(...)` would throw an exception due to the `$activity` property being `null`.