### PR TITLE
chore: update .gitattributes export-ignore paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,9 +4,14 @@
 # Ignore all test and documentation with "export-ignore".
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
-/tests              export-ignore
+/.github            export-ignore
 /.editorconfig      export-ignore
+/.php_cs.dist.php   export-ignore
+/.php_cs.laravel    export-ignore
+/phpunit.xml.dist   export-ignore
+/art                export-ignore
 /docs               export-ignore
+/tests              export-ignore
+/README.md          export-ignore
+/CHANGELOG.md       export-ignore
+/UPGRADING.md       export-ignore


### PR DESCRIPTION
**Update .gitattributes to exclude dev and asset files from export**

* Added `export-ignore` rules for `/art`, `/README.md`, changelog, upgrade guide, and CS config files
* Removed deprecated paths
* Reduced export size by excluding large unused asset (`art/socialcard.png`, \~500KB)
