### PR TITLE
chore: add return type to migration methods

### DIFF
--- a/database/migrations/add_batch_uuid_column_to_activity_log_table.php.stub
+++ b/database/migrations/add_batch_uuid_column_to_activity_log_table.php.stub
@@ -6,14 +6,14 @@ use Illuminate\Database\Migrations\Migration;
 
 class AddBatchUuidColumnToActivityLogTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table) {
             $table->uuid('batch_uuid')->nullable()->after('properties');
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table) {
             $table->dropColumn('batch_uuid');

--- a/database/migrations/add_event_column_to_activity_log_table.php.stub
+++ b/database/migrations/add_event_column_to_activity_log_table.php.stub
@@ -6,14 +6,14 @@ use Illuminate\Database\Migrations\Migration;
 
 class AddEventColumnToActivityLogTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table) {
             $table->string('event')->nullable()->after('subject_type');
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::connection(config('activitylog.database_connection'))->table(config('activitylog.table_name'), function (Blueprint $table) {
             $table->dropColumn('event');

--- a/database/migrations/create_activity_log_table.php.stub
+++ b/database/migrations/create_activity_log_table.php.stub
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreateActivityLogTable extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::connection(config('activitylog.database_connection'))->create(config('activitylog.table_name'), function (Blueprint $table) {
             $table->bigIncrements('id');
@@ -20,7 +20,7 @@ class CreateActivityLogTable extends Migration
         });
     }
 
-    public function down()
+    public function down(): void
     {
         Schema::connection(config('activitylog.database_connection'))->dropIfExists(config('activitylog.table_name'));
     }


### PR DESCRIPTION
This pull request updates the migration stub files for the activity log feature to improve code clarity and type safety. The main change is adding explicit `void` return types to the `up` and `down` methods in all relevant migration classes.

Migration method signature improvements:

* Added `: void` return type hints to the `up` and `down` methods in `CreateActivityLogTable`, `AddBatchUuidColumnToActivityLogTable`, and `AddEventColumnToActivityLogTable` migration stubs to ensure method signatures are explicit and consistent. [[1]](diffhunk://#diff-080accbb4441ebdad5848ea05482866bc8321561f95f4546e656ca3397fafdc8L9-R9) [[2]](diffhunk://#diff-080accbb4441ebdad5848ea05482866bc8321561f95f4546e656ca3397fafdc8L23-R23) [[3]](diffhunk://#diff-be1c1f963eb4064092a9c4ba6a8e30239084e67f5e04c6a0f808765f7cd2a840L9-R16) [[4]](diffhunk://#diff-fbcb186ff85d5a7c36a5813c49ddf3219a4b0fcadd7ddd79d50baebb6be77636L9-R16)