### PR TITLE
fix: ensure batch cleanup with try-finally in withinBatch method

### DIFF
--- a/src/LogBatch.php
+++ b/src/LogBatch.php
@@ -30,10 +30,11 @@ class LogBatch
     public function withinBatch(Closure $callback): mixed
     {
         $this->startBatch();
-        $result = $callback($this->getUuid());
-        $this->endBatch();
-
-        return $result;
+        try {
+            return $callback($this->getUuid());
+        } finally {
+            $this->endBatch();
+        }
     }
 
     public function startBatch(): void


### PR DESCRIPTION
- Use try-finally to guarantee endBatch() executes even during exceptions
- Prevent transaction counter corruption and stale batch state on errors
- Improve exception safety for batch operations