### PR TITLE
fix: add null safety and type hints to ActivityLogStatus

### DIFF
--- a/src/ActivityLogStatus.php
+++ b/src/ActivityLogStatus.php
@@ -6,11 +6,11 @@ use Illuminate\Contracts\Config\Repository;
 
 class ActivityLogStatus
 {
-    protected $enabled = true;
+    protected bool $enabled;
 
     public function __construct(Repository $config)
     {
-        $this->enabled = $config['activitylog.enabled'];
+        $this->enabled = (bool) ($config['activitylog.enabled'] ?? true);
     }
 
     public function enable(): bool


### PR DESCRIPTION
- Add bool type hint to  $enabled property
- Add null coalescing with default true for config value
- Cast config value to bool to ensure type consistency
- Prevent potential null/undefined config issues