### PR TITLE
Fix : type handling in CleanActivitylogCommand for --days option

### DIFF
--- a/src/CleanActivitylogCommand.php
+++ b/src/CleanActivitylogCommand.php
@@ -28,7 +28,7 @@ class CleanActivitylogCommand extends Command
 
         $log = $this->argument('log');
 
-        $maxAgeInDays = $this->option('days') ?? config('activitylog.delete_records_older_than_days');
+        $maxAgeInDays = (int) ($this->option('days') ?? config('activitylog.delete_records_older_than_days'));
 
         $cutOffDate = Carbon::now()->subDays($maxAgeInDays)->format('Y-m-d H:i:s');
 


### PR DESCRIPTION
Previously, the --days option passed to the activitylog:clean command or the configuration value 'delete_records_older_than_days' could be null or a string. This caused potential type issues when used with Carbon's subDays() method, which expects an integer.

This commit explicitly casts the value of  to (int), ensuring consistent behavior and preventing runtime errors when calculating the cutoff date for old activity log records.

No changes to functionality; purely a type safety improvement.