### PR TITLE
refactor: simplify changes() method using Collection::only()

### DIFF
--- a/tests/Models/Activity.php
+++ b/tests/Models/Activity.php
@@ -51,9 +51,7 @@ class Activity extends Model implements ActivityContract
             return new Collection();
         }
 
-        return collect(array_filter($this->properties->toArray(), function ($key) {
-            return in_array($key, ['attributes', 'old']);
-        }, ARRAY_FILTER_USE_KEY));
+        return $this->properties->only(['attributes', 'old']);
     }
 
     public function scopeInLog(Builder $query, ...$logNames): Builder

--- a/tests/Models/AnotherInvalidActivity.php
+++ b/tests/Models/AnotherInvalidActivity.php
@@ -57,9 +57,7 @@ class AnotherInvalidActivity implements ActivityContract
             return new Collection();
         }
 
-        return collect(array_filter($this->properties->toArray(), function ($key) {
-            return in_array($key, ['attributes', 'old']);
-        }, ARRAY_FILTER_USE_KEY));
+        return $this->properties->only(['attributes', 'old']);
     }
 
     public function scopeInLog(Builder $query, ...$logNames): Builder


### PR DESCRIPTION
- Replace array_filter with Collection::only() for better readability
- Maintain same functionality with cleaner implementation
- Leverage Laravel's built-in collection methods