### PR TITLE
Add support for returning soft-deleted causer models.

### DIFF
--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -31,6 +31,11 @@ return [
     'subject_returns_soft_deleted_models' => false,
 
     /*
+     * If set to true, the causer returns soft deleted models.
+     */
+    'causer_returns_soft_deleted_models' => false,
+
+    /*
      * This model will be used to log activity.
      * It should implement the Spatie\Activitylog\Contracts\Activity interface
      * and extend Illuminate\Database\Eloquent\Model.

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -65,6 +65,11 @@ return [
      * If set to true, the subject returns soft deleted models.
      */
     'subject_returns_soft_deleted_models' => false,
+    
+    /*
+     * If set to true, the causer returns soft deleted models.
+     */
+    'causer_returns_soft_deleted_models' => false,
 
     /*
      * This model will be used to log activity.

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -76,6 +76,10 @@ class Activity extends Model implements ActivityContract
      */
     public function causer(): MorphTo
     {
+        if (config('activitylog.causer_returns_soft_deleted_models')) {
+            return $this->morphTo()->withTrashed();
+        }
+
         return $this->morphTo();
     }
 


### PR DESCRIPTION
Previously, only soft-deleted **subject** models could be returned.
This PR adds support for returning soft-deleted **causer** models as well.