### PR TITLE
Use try/finally in withinBatch to close batch when callback throws

### DIFF
--- a/src/LogBatch.php
+++ b/src/LogBatch.php
@@ -30,8 +30,12 @@ class LogBatch
     public function withinBatch(Closure $callback): mixed
     {
         $this->startBatch();
-        $result = $callback($this->getUuid());
-        $this->endBatch();
+
+        try {
+            $result = $callback($this->getUuid());
+        } finally {
+            $this->endBatch();
+        }
 
         return $result;
     }

--- a/tests/LogBatchTest.php
+++ b/tests/LogBatchTest.php
@@ -124,3 +124,18 @@ it('will return null uuid if end batch that started twice properly', function ()
 
     $this->assertNotSame($firstUuid, $nullUuid);
 });
+
+it('closes the batch when the callback throws an exception', function () {
+    expect(LogBatch::isOpen())->toBeFalse();
+
+    try {
+        LogBatch::withinBatch(function () {
+            throw new \RuntimeException('something went wrong');
+        });
+    } catch (\RuntimeException) {
+        // swallow
+    }
+
+    expect(LogBatch::isOpen())->toBeFalse();
+    expect(LogBatch::getUuid())->toBeNull();
+});


### PR DESCRIPTION
## The problem

If the callback passed to `LogBatch::withinBatch()` throws an exception, `endBatch()` is never called:

```php
public function withinBatch(Closure $callback): mixed
{
    $this->startBatch();
    $result = $callback($this->getUuid()); // throws here
    $this->endBatch();                       // never runs

    return $result;
}
```

The batch counter and UUID remain set for the rest of the request. Any activity logged after catching the exception will be silently associated with the stale (never-closed) batch.

```php
try {
    LogBatch::withinBatch(function () {
        throw new \RuntimeException('something went wrong');
    });
} catch (\RuntimeException) {}

// Batch is still open - subsequent activity gets the wrong batch_uuid
LogBatch::isOpen(); // true (should be false)
LogBatch::getUuid(); // still set (should be null)
```

## Fix

Wrap the callback in `try/finally` so `endBatch()` always runs. This is the same pattern already used by `ActivityLogger::withoutLogs()`.

## Test

Added a test that confirms the batch is closed and the UUID is null even when the callback throws.