### PR TITLE
Fix LogOptions closure preventing model serialization in queued liste…

### DIFF
--- a/src/LogOptions.php
+++ b/src/LogOptions.php
@@ -3,6 +3,7 @@
 namespace Spatie\Activitylog;
 
 use Closure;
+use Laravel\SerializableClosure\SerializableClosure;
 
 class LogOptions
 {
@@ -162,5 +163,39 @@ class LogOptions
         $this->attributeRawValues = $attributes;
 
         return $this;
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'logName' => $this->logName,
+            'submitEmptyLogs' => $this->submitEmptyLogs,
+            'logFillable' => $this->logFillable,
+            'logOnlyDirty' => $this->logOnlyDirty,
+            'logUnguarded' => $this->logUnguarded,
+            'logAttributes' => $this->logAttributes,
+            'logExceptAttributes' => $this->logExceptAttributes,
+            'dontLogIfAttributesChangedOnly' => $this->dontLogIfAttributesChangedOnly,
+            'attributeRawValues' => $this->attributeRawValues,
+            'descriptionForEvent' => $this->descriptionForEvent
+                ? new SerializableClosure($this->descriptionForEvent)
+                : null,
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->logName = $data['logName'];
+        $this->submitEmptyLogs = $data['submitEmptyLogs'];
+        $this->logFillable = $data['logFillable'];
+        $this->logOnlyDirty = $data['logOnlyDirty'];
+        $this->logUnguarded = $data['logUnguarded'];
+        $this->logAttributes = $data['logAttributes'];
+        $this->logExceptAttributes = $data['logExceptAttributes'];
+        $this->dontLogIfAttributesChangedOnly = $data['dontLogIfAttributesChangedOnly'];
+        $this->attributeRawValues = $data['attributeRawValues'];
+        $this->descriptionForEvent = $data['descriptionForEvent']
+            ? $data['descriptionForEvent']->getClosure()
+            : null;
     }
 }

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -585,6 +585,19 @@ it('can be serialized', function () {
     $this->assertNotNull(serialize($model));
 });
 
+it('can serialize and unserialize LogOptions with a description closure', function () {
+    $options = LogOptions::defaults()
+        ->setDescriptionForEvent(function (string $eventName) {
+            return "Article was {$eventName}";
+        });
+
+    $serialized = serialize($options);
+    $unserialized = unserialize($serialized);
+
+    $this->assertEquals('Article was created', ($unserialized->descriptionForEvent)('created'));
+    $this->assertEquals('Article was updated', ($unserialized->descriptionForEvent)('updated'));
+});
+
 it('logs non backed enum casted attribute', function () {
     $articleClass = new class() extends Article {
         use LogsActivity;


### PR DESCRIPTION
…ners

Use Laravel's SerializableClosure in LogOptions __serialize/__unserialize to allow models with a descriptionForEvent closure to be serialized when passed to queued event listeners.

Fixes spatie/laravel-activitylog#1450