### PR TITLE
Fix LogOptions closure preventing model serialization in queued listeners

### DIFF
--- a/src/LogOptions.php
+++ b/src/LogOptions.php
@@ -167,35 +167,23 @@ class LogOptions
 
     public function __serialize(): array
     {
-        return [
-            'logName' => $this->logName,
-            'submitEmptyLogs' => $this->submitEmptyLogs,
-            'logFillable' => $this->logFillable,
-            'logOnlyDirty' => $this->logOnlyDirty,
-            'logUnguarded' => $this->logUnguarded,
-            'logAttributes' => $this->logAttributes,
-            'logExceptAttributes' => $this->logExceptAttributes,
-            'dontLogIfAttributesChangedOnly' => $this->dontLogIfAttributesChangedOnly,
-            'attributeRawValues' => $this->attributeRawValues,
-            'descriptionForEvent' => $this->descriptionForEvent
-                ? new SerializableClosure($this->descriptionForEvent)
-                : null,
-        ];
+        $data = get_object_vars($this);
+
+        if ($data['descriptionForEvent'] !== null) {
+            $data['descriptionForEvent'] = new SerializableClosure($data['descriptionForEvent']);
+        }
+
+        return $data;
     }
 
     public function __unserialize(array $data): void
     {
-        $this->logName = $data['logName'];
-        $this->submitEmptyLogs = $data['submitEmptyLogs'];
-        $this->logFillable = $data['logFillable'];
-        $this->logOnlyDirty = $data['logOnlyDirty'];
-        $this->logUnguarded = $data['logUnguarded'];
-        $this->logAttributes = $data['logAttributes'];
-        $this->logExceptAttributes = $data['logExceptAttributes'];
-        $this->dontLogIfAttributesChangedOnly = $data['dontLogIfAttributesChangedOnly'];
-        $this->attributeRawValues = $data['attributeRawValues'];
-        $this->descriptionForEvent = $data['descriptionForEvent']
-            ? $data['descriptionForEvent']->getClosure()
-            : null;
+        foreach ($data as $key => $value) {
+            if ($key === 'descriptionForEvent' && $value instanceof SerializableClosure) {
+                $value = $value->getClosure();
+            }
+
+            $this->$key = $value;
+        }
     }
 }

--- a/src/LogOptions.php
+++ b/src/LogOptions.php
@@ -3,6 +3,7 @@
 namespace Spatie\Activitylog;
 
 use Closure;
+use Laravel\SerializableClosure\SerializableClosure;
 
 class LogOptions
 {
@@ -162,5 +163,39 @@ class LogOptions
         $this->attributeRawValues = $attributes;
 
         return $this;
+    }
+
+    public function __serialize(): array
+    {
+        return [
+            'logName' => $this->logName,
+            'submitEmptyLogs' => $this->submitEmptyLogs,
+            'logFillable' => $this->logFillable,
+            'logOnlyDirty' => $this->logOnlyDirty,
+            'logUnguarded' => $this->logUnguarded,
+            'logAttributes' => $this->logAttributes,
+            'logExceptAttributes' => $this->logExceptAttributes,
+            'dontLogIfAttributesChangedOnly' => $this->dontLogIfAttributesChangedOnly,
+            'attributeRawValues' => $this->attributeRawValues,
+            'descriptionForEvent' => $this->descriptionForEvent
+                ? new SerializableClosure($this->descriptionForEvent)
+                : null,
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->logName = $data['logName'];
+        $this->submitEmptyLogs = $data['submitEmptyLogs'];
+        $this->logFillable = $data['logFillable'];
+        $this->logOnlyDirty = $data['logOnlyDirty'];
+        $this->logUnguarded = $data['logUnguarded'];
+        $this->logAttributes = $data['logAttributes'];
+        $this->logExceptAttributes = $data['logExceptAttributes'];
+        $this->dontLogIfAttributesChangedOnly = $data['dontLogIfAttributesChangedOnly'];
+        $this->attributeRawValues = $data['attributeRawValues'];
+        $this->descriptionForEvent = $data['descriptionForEvent']
+            ? $data['descriptionForEvent']->getClosure()
+            : null;
     }
 }

--- a/tests/LogsActivityTest.php
+++ b/tests/LogsActivityTest.php
@@ -585,6 +585,19 @@ it('can be serialized', function () {
     $this->assertNotNull(serialize($model));
 });
 
+it('can serialize and unserialize LogOptions with a description closure', function () {
+    $options = LogOptions::defaults()
+        ->setDescriptionForEvent(function (string $eventName) {
+            return "Article was {$eventName}";
+        });
+
+    $serialized = serialize($options);
+    $unserialized = unserialize($serialized);
+
+    $this->assertEquals('Article was created', ($unserialized->descriptionForEvent)('created'));
+    $this->assertEquals('Article was updated', ($unserialized->descriptionForEvent)('updated'));
+});
+
 it('logs non backed enum casted attribute', function () {
     $articleClass = new class() extends Article {
         use LogsActivity;


### PR DESCRIPTION
## Summary

- Use Laravel's `SerializableClosure` in `LogOptions` `__serialize`/`__unserialize` to allow models with a `descriptionForEvent` closure to be serialized when passed to queued event listeners.
- Uses `get_object_vars()` instead of manually listing properties, so the serialization logic doesn't need updating when properties are added or removed.

Based on #1451 by @morloderex. Fixes #1450.