### PR TITLE
Optimize migration snippet to target only affected rows using JSON queries

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,15 +24,20 @@ Schema::table('activity_log', function (Blueprint $table) {
 });
 
 // Then migrate existing data: move 'attributes' and 'old' from properties to attribute_changes
-DB::table('activity_log')->whereNotNull('properties')->eachById(function ($row) {
-    $properties = json_decode($row->properties, true);
-    $changes = array_intersect_key($properties, array_flip(['attributes', 'old']));
-    $remaining = array_diff_key($properties, array_flip(['attributes', 'old']));
+DB::table('activity_log')
+    ->where(function ($query) {
+        $query->whereNotNull('properties->attributes')
+            ->orWhereNotNull('properties->old');
+    })
+    ->eachById(function ($row) {
+        $properties = json_decode($row->properties, true);
+        $changes = array_intersect_key($properties, array_flip(['attributes', 'old']));
+        $remaining = array_diff_key($properties, array_flip(['attributes', 'old']));
 
-    DB::table('activity_log')->where('id', $row->id)->update([
-        'attribute_changes' => empty($changes) ? null : json_encode($changes),
-        'properties' => empty($remaining) ? null : json_encode($remaining),
-    ]);
+        DB::table('activity_log')->where('id', $row->id)->update([
+            'attribute_changes' => empty($changes) ? null : json_encode($changes),
+            'properties' => empty($remaining) ? null : json_encode($remaining),
+        ]);
 });
 ```
 


### PR DESCRIPTION
Replace `whereNotNull('properties')` with targeted JSON column queries (`whereNotNull('properties->attributes')` / `whereNotNull('properties->old')`) in the upgrade migration example
- This avoids iterating over every row with properties when only a subset actually has `attributes` or `old` keys to migrate

The current upgrade migration example scans all rows with non-null `properties`, decodes JSON in PHP, and updates every row — even those without `attributes` or `old` keys. On large `activity_log` tables (especially projects using custom properties heavily), this results in unnecessary processing and updates for the majority of rows.

As in my projects where there were large records but only 1/10th of it is effected so it does not make sense to iterate over every row